### PR TITLE
[#3] reset=false makes the meter import to restart from zero.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2024-12-23
+
+### Fixed
+[#3](https://github.com/ssenart/gazpar2haws/issues/3): reset=false makes the meter import to restart from zero.
+
 ## [0.1.1] - 2024-12-22
 
 ### Added
-
 [#1](https://github.com/ssenart/gazpar2haws/issues/1): Publish energy indicator in kWh.
 
 ## [0.1.0] - 2024-12-21

--- a/gazpar2haws/gazpar.py
+++ b/gazpar2haws/gazpar.py
@@ -77,12 +77,18 @@ class Gazpar:
 
             # Compute the number of days since the last statistics
             last_days = (datetime.now() - last_date).days
+
+            # Get the last meter value
+            last_value = last_statistics.get("sum")
         else:
             # If the sensor does not exist in Home Assistant, fetch the last days defined in the configuration
             last_days = self._last_days
 
             # Compute the corresponding last_date
             last_date = datetime.now() - timedelta(days=last_days)
+
+            # If no statistic, the last value is initialized to zero
+            last_value = 0
 
         # Initialize PyGazpar client
         client = pygazpar.Client(pygazpar.JsonWebDataSource(username=self._username, password=self._password))
@@ -100,7 +106,7 @@ class Gazpar:
         # Compute and fill statistics.
         daily = data.get(pygazpar.Frequency.DAILY.value)
         statistics = []
-        total = 0
+        total = last_value
         for reading in daily:
             # Parse date format DD/MM/YYYY into datetime.
             date = datetime.strptime(reading[pygazpar.PropertyName.TIME_PERIOD.value], "%d/%m/%Y")


### PR DESCRIPTION
### Fixed
[#3](https://github.com/ssenart/gazpar2haws/issues/3): reset=false makes the meter import to restart from zero.
