### PR TITLE
[#6] The last meter value may be imported multiple times and cause the today value being wrong.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.1.2] - 2024-12-23
 
 ### Fixed
+[#6](https://github.com/ssenart/gazpar2haws/issues/6): The last meter value may be imported multiple times and cause the today value being wrong.
 [#3](https://github.com/ssenart/gazpar2haws/issues/3): reset=false makes the meter import to restart from zero.
 
 ## [0.1.1] - 2024-12-22

--- a/gazpar2haws/gazpar.py
+++ b/gazpar2haws/gazpar.py
@@ -64,22 +64,22 @@ class Gazpar:
             raise Exception(errorMessage)
 
         if exists_statistic_id:
-            # Get last statistics from GrDF
+            # Get the last statistic from Home Assistant
             try:
-                last_statistics = await self._homeassistant.get_last_statistic(entity_id)
+                last_statistic = await self._homeassistant.get_last_statistic(entity_id)
             except Exception:
                 errorMessage = f"Error while fetching last statistics from Home Assistant: {traceback.format_exc()}"
                 Logger.warning(errorMessage)
                 raise Exception(errorMessage)
 
             # Extract the end date of the last statistics from the unix timestamp
-            last_date = datetime.fromtimestamp(last_statistics.get("end") / 1000)
+            last_date = datetime.fromtimestamp(last_statistic.get("end") / 1000)
 
             # Compute the number of days since the last statistics
             last_days = (datetime.now() - last_date).days
 
             # Get the last meter value
-            last_value = last_statistics.get("sum")
+            last_value = last_statistic.get("sum")
         else:
             # If the sensor does not exist in Home Assistant, fetch the last days defined in the configuration
             last_days = self._last_days
@@ -112,7 +112,7 @@ class Gazpar:
             date = datetime.strptime(reading[pygazpar.PropertyName.TIME_PERIOD.value], "%d/%m/%Y")
 
             # Skip all readings before the last statistic date.
-            if date.date() < last_date.date():
+            if date.date() <= last_date.date():
                 continue
 
             # Set the timezone

--- a/gazpar2haws/gazpar.py
+++ b/gazpar2haws/gazpar.py
@@ -73,7 +73,7 @@ class Gazpar:
                 raise Exception(errorMessage)
 
             # Extract the end date of the last statistics from the unix timestamp
-            last_date = datetime.fromtimestamp(last_statistic.get("end") / 1000)
+            last_date = datetime.fromtimestamp(last_statistic.get("start") / 1000)
 
             # Compute the number of days since the last statistics
             last_days = (datetime.now() - last_date).days
@@ -89,6 +89,8 @@ class Gazpar:
 
             # If no statistic, the last value is initialized to zero
             last_value = 0
+
+        Logger.debug(f"Last date: {last_date}, last days: {last_days}, last value: {last_value}")
 
         # Initialize PyGazpar client
         client = pygazpar.Client(pygazpar.JsonWebDataSource(username=self._username, password=self._password))
@@ -113,6 +115,7 @@ class Gazpar:
 
             # Skip all readings before the last statistic date.
             if date.date() <= last_date.date():
+                Logger.debug(f"Skip date: {date.date()} <= {last_date.date()}")
                 continue
 
             # Set the timezone


### PR DESCRIPTION
### Fixed
[#6](https://github.com/ssenart/gazpar2haws/issues/6): The last meter value may be imported multiple times and cause the today value being wrong.