### PR TITLE
[#9] Incorrect timezone info creates duplicate import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [#2](https://github.com/ssenart/gazpar2haws/issues/2): DockerHub deployment.
 
 ### Fixed
+[#9](https://github.com/ssenart/gazpar2haws/issues/9): Incorrect timezone info creates duplicate import.
+
 [#6](https://github.com/ssenart/gazpar2haws/issues/6): The last meter value may be imported multiple times and cause the today value being wrong.
+
 [#3](https://github.com/ssenart/gazpar2haws/issues/3): reset=false makes the meter import to restart from zero.
 
 ## [0.1.1] - 2024-12-22

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ In a Docker environment, the configurations files are instantiated by replacing 
 |---|---|---|---|
 | GRDF_USERNAME  |  GrDF account user name  | Yes | - |
 | GRDF_PASSWORD  |  GrDF account password (avoid using special characters) | Yes | - |
-| GRDF_PCE_IDENTIFIER  | GrDF meter PCI identifier  | Yes | - |
+| GRDF_PCE_IDENTIFIER  | GrDF meter PCE identifier  | Yes | - |
 | GRDF_SCAN_INTERVAL  | Period in minutes to refresh meter data (0 means one single refresh and stop) | No | 480 (8 hours) |
 | GRDF_LAST_DAYS | Number of days of history data to retrieve  | No | 1095 (3 years) |
 | HOMEASSISTANT_HOST  | Home Assistant instance host name  | Yes | - |


### PR DESCRIPTION
### Fixed
[#9](https://github.com/ssenart/gazpar2haws/issues/9): Incorrect timezone info creates duplicate import.