### PR TITLE
Add amd64 build support in ci

### DIFF
--- a/.github/workflows/publish-to-dockerhub/action.yaml
+++ b/.github/workflows/publish-to-dockerhub/action.yaml
@@ -47,6 +47,7 @@ runs:
       with:
         context: "{{defaultContext}}"
         file: ./docker/Dockerfile
+        platforms: linux/amd64,linux/arm64
         push: true
         tags: ${{ steps.meta.outputs.tags }}
         labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Hi,

Thanks for your work! 
I would like to try it on on my NAS but the docker image is only built for arm64 platform.
I would need to make it also compatible on amd64 platform.

Here is my proposal for that.

Thanks,
Regards