### PR TITLE
[#33] Dockerhub 'latest' tag is currently published only if the release is created in the main branch.

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      is_final:
+        description: "Whether it is a final release (not a pre-release)"
+        required: false
+        default: true
+        type: boolean
 
 permissions:
   contents: write # Allow to commit and push.
@@ -210,5 +215,6 @@ jobs:
         with:
           image: ssenart/gazpar2haws
           version: ${{ needs.prepare.outputs.package-version }}
+          is_latest : ${{ inputs.is_final }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -90,8 +90,8 @@ jobs:
         run: sudo apt-get update && sudo apt-get install -y gettext-base
 
       #----------------------------------------------
-      # Replace version in pyproject.toml, config.yaml and build.yaml
-      - name: Replace version
+      # Bump version in pyproject.toml, config.yaml and build.yaml
+      - name: Bump version
         run: |
           envsubst < pyproject.template.toml > pyproject.toml
           envsubst < addons/gazpar2haws/config.yaml.template > addons/gazpar2haws/config.yaml
@@ -105,7 +105,7 @@ jobs:
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
           git add pyproject.toml addons/gazpar2haws/config.yaml addons/gazpar2haws/build.yaml
-          git commit --allow-empty -m "Upgrade version to ${PACKAGE_VERSION}"
+          git commit --allow-empty -m "Bump version to ${PACKAGE_VERSION}"
           git push
 
       #----------------------------------------------

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -9,7 +9,7 @@ on:
         default: ""
         type: string
       is_final:
-        description: "Whether it is a final release (not a pre-release)"
+        description: "It is a final release (not a pre-release)"
         required: false
         default: true
         type: boolean

--- a/.github/workflows/publish-to-dockerhub.yaml
+++ b/.github/workflows/publish-to-dockerhub.yaml
@@ -8,8 +8,8 @@ on:
         required: false
         default: ""
         type: string
-      is_final:
-        description: "It is a final release (not a pre-release)"
+      is_latest:
+        description: "Update the 'latest' tag"
         required: false
         default: true
         type: boolean        
@@ -91,6 +91,6 @@ jobs:
         with:
           image: ssenart/gazpar2haws
           version: ${{ needs.prepare.outputs.package-version }}
-          is_latest: ${{ inputs.is_final }}
+          is_latest: ${{ inputs.is_latest }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/publish-to-dockerhub.yaml
+++ b/.github/workflows/publish-to-dockerhub.yaml
@@ -8,6 +8,11 @@ on:
         required: false
         default: ""
         type: string
+      is_final:
+        description: "Whether it is a final release (not a pre-release)"
+        required: false
+        default: true
+        type: boolean        
 
 permissions:
   contents: read # Readonly permissions
@@ -17,9 +22,9 @@ env:
 
 jobs:
   #----------------------------------------------
-  # Collect information
-  information:
-    name: Collect information
+  # Prepare
+  prepare:
+    name: Prepare
     outputs:
       package-version: ${{ steps.select-package-version.outputs.package-version }}
       default_python_version: ${{ env.DEFAULT_PYTHON_VERSION }}
@@ -66,7 +71,7 @@ jobs:
   # Publish Docker image to DockerHub
   publish-to-dockerhub:
     name: Publish to DockerHub
-    needs: information
+    needs: prepare
     runs-on: ubuntu-latest
     permissions:
       packages: write
@@ -85,6 +90,7 @@ jobs:
         uses: ./.github/workflows/publish-to-dockerhub
         with:
           image: ssenart/gazpar2haws
-          version: ${{ needs.information.outputs.package-version }}
+          version: ${{ needs.prepare.outputs.package-version }}
+          is_latest: ${{ inputs.is_final }}
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/publish-to-dockerhub.yaml
+++ b/.github/workflows/publish-to-dockerhub.yaml
@@ -9,7 +9,7 @@ on:
         default: ""
         type: string
       is_final:
-        description: "Whether it is a final release (not a pre-release)"
+        description: "It is a final release (not a pre-release)"
         required: false
         default: true
         type: boolean        

--- a/.github/workflows/publish-to-dockerhub/action.yaml
+++ b/.github/workflows/publish-to-dockerhub/action.yaml
@@ -10,6 +10,10 @@ inputs:
   version:
     description: "Version of the image"
     required: true
+  is_latest: 
+    description: "Whether the version is a final release"
+    required: false
+    default: false
   username:
     description: "DockerHub username"
     required: true
@@ -39,7 +43,7 @@ runs:
         images: ${{ inputs.image }}
         tags: |
           # Set latest tag for the default branch
-          type=raw,value=latest,enable={{is_default_branch}}
+          type=raw,value=latest,enable=${{ inputs.is_latest }}
           # Set the version tag for all branches
           type=raw,value=${{ inputs.version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.12] - 2025-01-13
+
+### Added
+
+[#33](https://github.com/ssenart/gazpar2haws/issues/33): Dockerhub 'latest' tag is currently published only if the release is created in the main branch.
+
 ## [0.1.11] - 2025-01-12
 
 ### Fixed


### PR DESCRIPTION
### Added

[#33](https://github.com/ssenart/gazpar2haws/issues/33): Dockerhub 'latest' tag is currently published only if the release is created in the main branch.