### PR TITLE
[#36] Error if HA endpoint configuration is missing in configuration.yaml.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.11] - 2025-01-15
+## [0.1.12] - 2025-01-15
 
 ### Fixed
 
 [#36](https://github.com/ssenart/gazpar2haws/issues/36): Error if HA endpoint configuration is missing in configuration.yaml.
+
+## [0.1.11] - 2025-01-12
+
+### Fixed
 
 [#32](https://github.com/ssenart/gazpar2haws/issues/32): Fix fatal happening after introducing as_of_date for tests.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.11] - 2025-01-12
+## [0.1.11] - 2025-01-15
 
 ### Fixed
+
+[#36](https://github.com/ssenart/gazpar2haws/issues/36): Error if HA endpoint configuration is missing in configuration.yaml.
 
 [#32](https://github.com/ssenart/gazpar2haws/issues/32): Fix fatal happening after introducing as_of_date for tests.
 

--- a/gazpar2haws/bridge.py
+++ b/gazpar2haws/bridge.py
@@ -16,12 +16,30 @@ class Bridge:
     def __init__(self, config: config_utils.ConfigLoader):
 
         # GrDF scan interval (in seconds)
+        if config.get("grdf.scan_interval") is None:
+            raise ValueError("Configuration parameter 'grdf.scan_interval' is missing")
         self._grdf_scan_interval = int(config.get("grdf.scan_interval"))
 
-        # Home Assistant configuration
+        # Home Assistant configuration: host
+        if config.get("homeassistant.host") is None:
+            raise ValueError("Configuration parameter 'homeassistant.host' is missing")
         ha_host = config.get("homeassistant.host")
+
+        # Home Assistant configuration: port
+        if config.get("homeassistant.port") is None:
+            raise ValueError("Configuration parameter 'homeassistant.port' is missing")
         ha_port = config.get("homeassistant.port")
-        ha_endpoint = config.get("homeassistant.endpoint")
+
+        # Home Assistant configuration: endpoint
+        ha_endpoint = (
+            config.get("homeassistant.endpoint")
+            if config.get("homeassistant.endpoint")
+            else "/api/websocket"
+        )
+
+        # Home Assistant configuration: token
+        if config.get("homeassistant.token") is None:
+            raise ValueError("Configuration parameter 'homeassistant.token' is missing")
         ha_token = config.get("homeassistant.token")
 
         # Initialize Home Assistant
@@ -29,6 +47,9 @@ class Bridge:
 
         # Initialize Gazpar
         self._gazpar = []
+
+        if config.get("grdf.devices") is None:
+            raise ValueError("Configuration parameter 'grdf.devices' is missing")
         for grdf_device_config in config.get("grdf.devices"):
             self._gazpar.append(Gazpar(grdf_device_config, self._homeassistant))
 

--- a/gazpar2haws/gazpar.py
+++ b/gazpar2haws/gazpar.py
@@ -19,15 +19,59 @@ class Gazpar:
 
         self._homeassistant = homeassistant
 
-        # GrDF configuration
+        # GrDF configuration: name
+        if config.get("name") is None:
+            raise ValueError("Configuration parameter 'grdf.devices[].name' is missing")
         self._name = config.get("name")
-        self._data_source = config.get("data_source")
+
+        # GrDF configuration: data source
+        self._data_source = (
+            config.get("data_source") if config.get("data_source") else "json"
+        )
+
+        # GrDF configuration: username
+        if self._data_source != "test" and config.get("username") is None:
+            raise ValueError(
+                "Configuration parameter 'grdf.devices[].username' is missing"
+            )
         self._username = config.get("username")
+
+        # GrDF configuration: password
+        if self._data_source != "test" and config.get("password") is None:
+            raise ValueError(
+                "Configuration parameter 'grdf.devices[].password' is missing"
+            )
         self._password = config.get("password")
+
+        # GrDF configuration: pce_identifier
+        if self._data_source != "test" and config.get("pce_identifier") is None:
+            raise ValueError(
+                "Configuration parameter 'grdf.devices[].pce_identifier' is missing"
+            )
         self._pce_identifier = str(config.get("pce_identifier"))
-        self._tmp_dir = config.get("tmp_dir")
+
+        # GrDF configuration: tmp_dir
+        self._tmp_dir = config.get("tmp_dir") if config.get("tmp_dir") else "/tmp"
+
+        # GrDF configuration: last_days
+        if config.get("last_days") is None:
+            raise ValueError(
+                "Configuration parameter 'grdf.devices[].last_days' is missing"
+            )
         self._last_days = int(str(config.get("last_days")))
+
+        # GrDF configuration: timezone
+        if config.get("timezone") is None:
+            raise ValueError(
+                "Configuration parameter 'grdf.devices[].timezone' is missing"
+            )
         self._timezone = str(config.get("timezone"))
+
+        # GrDF configuration: reset
+        if config.get("reset") is None:
+            raise ValueError(
+                "Configuration parameter 'grdf.devices[].reset' is missing"
+            )
         self._reset = bool(config.get("reset"))
 
         # As of date: YYYY-MM-DD

--- a/tests/config/configuration.yaml
+++ b/tests/config/configuration.yaml
@@ -17,5 +17,4 @@ grdf:
 homeassistant:
   host: "!secret homeassistant.host"
   port: "!secret homeassistant.port"
-  endpoint: "/api/websocket"
   token: "!secret homeassistant.token"

--- a/tests/test_gazpar.py
+++ b/tests/test_gazpar.py
@@ -24,7 +24,11 @@ class TestGazpar:
 
         ha_host = self._config.get("homeassistant.host")
         ha_port = self._config.get("homeassistant.port")
-        ha_endpoint = self._config.get("homeassistant.endpoint")
+        ha_endpoint = (
+            self._config.get("homeassistant.endpoint")
+            if self._config.get("homeassistant.endpoint")
+            else "/api/websocket"
+        )
         ha_token = self._config.get("homeassistant.token")
 
         self._haws = HomeAssistantWS(  # pylint: disable=W0201

--- a/tests/test_haws.py
+++ b/tests/test_haws.py
@@ -27,7 +27,11 @@ class TestHomeAssistantWS:
 
         ha_host = self._config.get("homeassistant.host")
         ha_port = self._config.get("homeassistant.port")
-        ha_endpoint = self._config.get("homeassistant.endpoint")
+        ha_endpoint = (
+            self._config.get("homeassistant.endpoint")
+            if self._config.get("homeassistant.endpoint")
+            else "/api/websocket"
+        )
         ha_token = self._config.get("homeassistant.token")
 
         self._haws = HomeAssistantWS(  # pylint: disable=W0201


### PR DESCRIPTION
### Fixed

[#36](https://github.com/ssenart/gazpar2haws/issues/36): Error if HA endpoint configuration is missing in configuration.yaml.