### PR TITLE
[#50] In dockerhub, version displayed in log file is wrong and always N-1

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -204,9 +204,11 @@ jobs:
       id-token: write
     steps:
       #----------------------------------------------
-      #  Check-out repo
+      #  Checkout the tag from the repository
       - name: Check out repository
         uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.package-version }}
 
       #----------------------------------------------
       # Publish the Docker image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.14] - 2025-01-17
+
+### Fixed
+
+[#50](https://github.com/ssenart/gazpar2haws/issues/50): In dockerhub, version displayed in log file is wrong and always N-1.
+
 ## [0.1.13] - 2025-01-16
 
 ### Fixed

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,6 @@ WORKDIR /app
 
 COPY pyproject.toml ./
 COPY poetry.lock ./
-COPY README.md ./
-COPY LICENSE ./
 
 COPY gazpar2haws/ /app/gazpar2haws
 
@@ -48,6 +46,9 @@ RUN  chmod +x /app/entrypoint.sh
 COPY gazpar2haws/ /app/gazpar2haws
 RUN  mkdir /app/config
 RUN  mkdir /app/log
+COPY README.md /app
+COPY CHANGELOG.md /app
+COPY LICENCE /app
 COPY config/configuration.template.yaml /app
 COPY config/secrets.template.yaml /app
 


### PR DESCRIPTION
### Fixed

[#50](https://github.com/ssenart/gazpar2haws/issues/50): In dockerhub, version displayed in log file is wrong and always N-1.