### PR TITLE
feat(entities) Specify device classes and units

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -366,12 +366,12 @@ The application follows a layered architecture with three main components:
 
 The Pricer ([pricer.py](gazpar2haws/pricer.py)) implements a sophisticated cost calculation system:
 
-- **CompositePriceValue**: Represents prices with both quantity and time components (e.g., €/kWh + €/month)
+- **CompositePriceValue**: Represents prices with both quantity and time components (e.g., EUR/kWh + EUR/month)
 - **CompositePriceArray**: Vectorized form holding both quantity_value_array and time_value_array
 - **CostBreakdown**: Result structure with separate consumption, subscription, transport, energy_taxes, and total cost arrays
 - **VAT support**: Multiple VAT rates (reduced, normal) applied to different price components
 - **Time-varying prices**: Prices change over time, with automatic interpolation
-- **Unit conversion**: Automatic conversion between price units (€, ¢), quantity units (Wh, kWh, MWh), and time units (day, week, month, year)
+- **Unit conversion**: Automatic conversion between quantity units (Wh, kWh, MWh), and time units (day, week, month, year)
 - **Formula**: `cost = quantity × (consumption_price + energy_taxes) + subscription_price + transport_price` (all with VAT applied)
 
 ### Data Model
@@ -409,11 +409,11 @@ Always published:
 - `sensor.${name}_energy` (kWh)
 
 Published when pricing configuration is provided:
-- `sensor.${name}_consumption_cost` (€) - Variable cost from gas consumption
-- `sensor.${name}_subscription_cost` (€) - Fixed subscription fees
-- `sensor.${name}_transport_cost` (€) - Transport fees (fixed or variable)
-- `sensor.${name}_energy_taxes_cost` (€) - Energy taxes
-- `sensor.${name}_total_cost` (€) - Sum of all cost components
+- `sensor.${name}_consumption_cost` (EUR) - Variable cost from gas consumption
+- `sensor.${name}_subscription_cost` (EUR) - Fixed subscription fees
+- `sensor.${name}_transport_cost` (EUR) - Transport fees (fixed or variable)
+- `sensor.${name}_energy_taxes_cost` (EUR) - Energy taxes
+- `sensor.${name}_total_cost` (EUR) - Sum of all cost components
 
 Where `${name}` is the device name from configuration (default: `gazpar2haws`)
 
@@ -482,16 +482,16 @@ PyGazpar supports multiple data sources:
 
 PCE identifiers must be quoted in YAML to preserve leading zeros. Unquoted values like `0123456789` are interpreted as numbers and lose the leading zero.
 
-### Pricing Configuration Format (v0.4.0)
+### Pricing Configuration Format (v0.5.0)
 
 The pricing configuration uses the composite price model:
 
 **YAML Properties:**
-- `quantity_value`: Numeric value for quantity-based pricing (e.g., 0.07790 for €/kWh)
+- `quantity_value`: Numeric value for quantity-based pricing (e.g., 0.07790 for EUR/kWh)
 - `quantity_unit`: Energy unit (Wh, kWh, MWh) - default: kWh
-- `time_value`: Numeric value for time-based pricing (e.g., 19.83 for €/month)
+- `time_value`: Numeric value for time-based pricing (e.g., 19.83 for EUR/month)
 - `time_unit`: Time unit (day, week, month, year) - default: month
-- `price_unit`: Monetary unit (€, ¢) - default: €
+- `price_unit`: Monetary unit (EUR, USD, ...) - default: EUR
 - `vat_id`: Reference to VAT rate ID
 
 **Price Type Guidelines:**
@@ -499,6 +499,9 @@ The pricing configuration uses the composite price model:
 - **subscription_prices**: Use `time_value` + `time_unit` (month/year)
 - **transport_prices**: Use either `time_value` (fixed fee) OR `quantity_value` (per kWh)
 - **energy_taxes**: Use `quantity_value` + `quantity_unit` (kWh)
+
+**Deprecated (v0.4.x):**
+- `time_unit` → Possible values `€` and `¢` replaced by `EUR` or other [ISO-4217 codes](https://en.wikipedia.org/wiki/ISO_4217#Active_codes)
 
 **Deprecated (v0.3.x):**
 - `value` → replaced by `quantity_value` or `time_value`

--- a/FAQ.md
+++ b/FAQ.md
@@ -230,6 +230,32 @@ pricing:
       vat_id: "normal"
 ```
 
+### I upgraded to v0.5.0 and my pricing configuration doesn't work
+
+**Issue:** [#83](https://github.com/ssenart/gazpar2haws/issues/83)
+
+**Cause:** v0.5.0 introduced a **breaking change** in the pricing configuration format.
+
+**Solution:** Migrate your configuration from the old format to the new format:
+
+**Old format (v0.4.0+):**
+```yaml
+consumption_prices:
+  - start_date: "2025-12-22"
+    quantity_value: 0.07791
+    price_unit: "€"
+    quantity_unit: "kWh"
+```
+
+**New format (v0.5.0+):**
+```yaml
+consumption_prices:
+  - start_date: "2025-12-22"
+    quantity_value: 0.07791
+    price_unit: "EUR"  # Currency: ISO 4217 code
+    quantity_unit: "kWh"
+```
+
 ### I upgraded to v0.4.0 and my pricing configuration doesn't work
 
 **Issue:** [#83](https://github.com/ssenart/gazpar2haws/issues/83)
@@ -247,16 +273,22 @@ consumption_prices:
     base_unit: "kWh"
 ```
 
-**New format (v0.4.0+):**
+**New format:**
 ```yaml
 consumption_prices:
   - start_date: "2023-06-01"
-    quantity_value: 0.07790  # Renamed from 'value'
-    price_unit: "€"          # Renamed from 'value_unit'
-    quantity_unit: "kWh"     # Renamed from 'base_unit'
+    quantity_value: 0.07790               # Renamed from 'value'
+    price_unit: "EUR"  # or € in v.0.4.0  # Renamed from 'value_unit'
+    quantity_unit: "kWh"                  # Renamed from 'base_unit'
 ```
 
 See [README.md Migration Guide](README.md#migration-from-v03x-to-v040) for complete migration instructions.
+
+### What are the new cost units in v0.5.0?
+
+Starting from v0.5.0, Gazpar2HAWS publishes the cost entities with a Standardized unit instead of a raw string. Units are now based on the [ISO-4217 codes](https://en.wikipedia.org/wiki/ISO_4217#Active_codes).
+
+This standardizes the montetary sensor in Home Automation.
 
 ### What are the new cost entities in v0.4.0?
 
@@ -279,7 +311,7 @@ This allows detailed cost analysis in Home Assistant.
 transport_prices:
   - start_date: "2023-06-01"
     time_value: 34.38
-    price_unit: "€"
+    price_unit: "EUR" # or € in v.0.4.0
     time_unit: "year"
 ```
 
@@ -288,7 +320,7 @@ transport_prices:
 transport_prices:
   - start_date: "2023-06-01"
     quantity_value: 0.00194
-    price_unit: "€"
+    price_unit: "EUR" # or € in v.0.4.0
     quantity_unit: "kWh"
 ```
 
@@ -296,9 +328,9 @@ transport_prices:
 
 The complete formula is:
 ```
-cost[€] = quantity[kWh] × (consumption_price[€/kWh] + energy_taxes[€/kWh]) × (1 + vat)
-        + subscription_price[€/month] × (1 + vat)
-        + transport_price[€/year or €/kWh] × (1 + vat)
+cost[EUR] = quantity[kWh] × (consumption_price[EUR/kWh] + energy_taxes[EUR/kWh]) × (1 + vat)
+          + subscription_price[EUR/month] × (1 + vat)
+          + transport_price[EUR/year or EUR/kWh] × (1 + vat)
 ```
 
 Each component can have different VAT rates and supports time-varying prices.
@@ -316,11 +348,11 @@ For each device, the following entities are created:
 - `sensor.${name}_energy` - Energy in kWh
 
 **Created when pricing is configured:**
-- `sensor.${name}_consumption_cost` - Consumption cost in €
-- `sensor.${name}_subscription_cost` - Subscription cost in €
-- `sensor.${name}_transport_cost` - Transport cost in €
-- `sensor.${name}_energy_taxes_cost` - Energy taxes in €
-- `sensor.${name}_total_cost` - Total cost in €
+- `sensor.${name}_consumption_cost` - Consumption cost in EUR
+- `sensor.${name}_subscription_cost` - Subscription cost in EUR
+- `sensor.${name}_transport_cost` - Transport cost in EUR
+- `sensor.${name}_energy_taxes_cost` - Energy taxes in EUR
+- `sensor.${name}_total_cost` - Total cost in EUR
 
 Where `${name}` is the device name from your configuration (default: `gazpar2haws`).
 
@@ -597,17 +629,17 @@ v0.4.0 introduces **breaking changes** in the pricing configuration format. Your
 
 ### What's the difference between `quantity_value` and `time_value`?
 
-- **`quantity_value`**: Price based on consumption amount (e.g., €/kWh)
+- **`quantity_value`**: Price based on consumption amount (e.g., EUR/kWh)
   - Used for: Consumption prices, Energy taxes, Transport (consumption-based)
   - Applied per unit consumed
 
-- **`time_value`**: Price based on time period (e.g., €/month, €/year)
+- **`time_value`**: Price based on time period (e.g., EUR/month, EUR/year)
   - Used for: Subscription fees, Transport (fixed), Standing charges
   - Applied per time period, regardless of consumption
 
 **Example:**
-- Consumption at €0.07790/kWh uses `quantity_value: 0.07790` (€ per each kWh)
-- Subscription at €19.83/month uses `time_value: 19.83` (€ for the entire month)
+- Consumption at 0.07790 EUR/kWh uses `quantity_value: 0.07790` (EUR per each kWh)
+- Subscription at 19.83 EUR/month uses `time_value: 19.83` (EUR for the entire month)
 
 See [MIGRATIONS.md](MIGRATIONS.md) for detailed examples of each type.
 

--- a/MIGRATIONS.md
+++ b/MIGRATIONS.md
@@ -14,7 +14,7 @@ This document provides step-by-step instructions for upgrading Gazpar2HAWS betwe
 
 ---
 
-## Upgrading from v0.3.x to v0.4.0
+## Upgrading from v0.3.x
 
 ### What Changed
 
@@ -55,36 +55,43 @@ The pricing configuration format has changed to support the composite price mode
 - `time_value` - The numeric value for the time component (e.g., €/month)
 - `time_unit` - The unit for time-based pricing (day, week, month, year)
 
+#### New Properties (v0.5.0)
+
+- `price_unit` - The monetary unit (EUR or any [ISO-4217 codes](https://en.wikipedia.org/wiki/ISO_4217#Active_codes))
+
 #### Quick Reference Table
 
 | Price Type | Old Format | New Format | Example |
 |------------|------------|------------|---------|
-| Consumption | `value: 0.07790` `base_unit: kWh` | `quantity_value: 0.07790` `quantity_unit: kWh` | €/kWh pricing |
-| Subscription | `value: 19.83` `base_unit: month` | `time_value: 19.83` `time_unit: month` | €/month fee |
-| Transport (fixed) | `value: 34.38` `base_unit: year` | `time_value: 34.38` `time_unit: year` | €/year fee |
-| Transport (variable) | Not available | `quantity_value: 0.00194` `quantity_unit: kWh` | **NEW**: €/kWh fee |
-| Energy Taxes | `value: 0.00837` `base_unit: kWh` | `quantity_value: 0.00837` `quantity_unit: kWh` | €/kWh tax |
+| Consumption | `value: 0.07790` `base_unit: kWh` | `quantity_value: 0.07790` `quantity_unit: kWh` | EUR/kWh pricing |
+| Subscription | `value: 19.83` `base_unit: month` | `time_value: 19.83` `time_unit: month` | EUR/month fee |
+| Transport (fixed) | `value: 34.38` `base_unit: year` | `time_value: 34.38` `time_unit: year` | EUR/year fee |
+| Transport (variable) | Not available | `quantity_value: 0.00194` `quantity_unit: kWh` | **NEW**: EUR/kWh fee |
+| Energy Taxes | `value: 0.00837` `base_unit: kWh` | `quantity_value: 0.00837` `quantity_unit: kWh` | EUR/kWh tax |
 
 ---
 
 ### Migration Examples
 
 #### Example 1: Simple Consumption Price
+<details>
+  <summary>From v0.3.x:</summary>
 
-**Before (v0.3.x):**
 ```yaml
 pricing:
   consumption_prices:
     - start_date: "2023-06-01"
-      value: 0.07790  # €/kWh
+      value: 0.07790  # EUR/kWh
 ```
+</details>
 
-**After (v0.4.0):**
+**To v0.4.0+**
+
 ```yaml
 pricing:
   consumption_prices:
     - start_date: "2023-06-01"
-      quantity_value: 0.07790  # €/kWh
+      quantity_value: 0.07790  # EUR/kWh
 ```
 
 **Explanation**: The `value` property is replaced by `quantity_value` since consumption is based on quantity (kWh).
@@ -92,8 +99,9 @@ pricing:
 ---
 
 #### Example 2: Consumption Price with Custom Units
+<details>
+  <summary>From v0.3.x</summary>
 
-**Before (v0.3.x):**
 ```yaml
 pricing:
   consumption_prices:
@@ -102,14 +110,28 @@ pricing:
       value_unit: "¢"     # cents
       base_unit: "MWh"    # megawatt-hour
 ```
+</details>
 
-**After (v0.4.0):**
+<details>
+  <summary>From v0.4.0:</summary>
+
 ```yaml
 pricing:
   consumption_prices:
     - start_date: "2023-06-01"
       quantity_value: 7790.0
       price_unit: "¢"      # cents
+      quantity_unit: "MWh" # megawatt-hour
+```
+</details>
+
+**To v0.5.0:**
+```yaml
+pricing:
+  consumption_prices:
+    - start_date: "2023-06-01"
+      quantity_value: 77.90
+      price_unit: "EUR"      # cents
       quantity_unit: "MWh" # megawatt-hour
 ```
 
@@ -121,8 +143,9 @@ pricing:
 ---
 
 #### Example 3: Subscription Price
+<details>
+  <summary>From v0.3.x</summary>
 
-**Before (v0.3.x):**
 ```yaml
 pricing:
   subscription_prices:
@@ -132,14 +155,29 @@ pricing:
       base_unit: "month"
       vat_id: "reduced"
 ```
+</details>
 
-**After (v0.4.0):**
+<details>
+  <summary>From v0.4.0</summary>
+
 ```yaml
 pricing:
   subscription_prices:
     - start_date: "2023-06-01"
       time_value: 19.83
       price_unit: "€"
+      time_unit: "month"
+      vat_id: "reduced"
+```
+</details>
+
+**To v0.5.0:**
+```yaml
+pricing:
+  subscription_prices:
+    - start_date: "2023-06-01"
+      time_value: 19.83
+      price_unit: "EUR"
       time_unit: "month"
       vat_id: "reduced"
 ```
@@ -153,7 +191,9 @@ pricing:
 
 #### Example 4: Transport Price (Fixed Fee)
 
-**Before (v0.3.x):**
+<details>
+  <summary>From v0.3.x</summary>
+
 ```yaml
 pricing:
   transport_prices:
@@ -163,14 +203,29 @@ pricing:
       base_unit: "year"
       vat_id: "reduced"
 ```
+</details>
 
-**After (v0.4.0):**
+<details>
+  <summary>From v0.4.0</summary>
+
 ```yaml
 pricing:
   transport_prices:
     - start_date: "2023-06-01"
       time_value: 34.38
       price_unit: "€"
+      time_unit: "year"
+      vat_id: "reduced"
+```
+</details>
+
+**To v0.5.0:**
+```yaml
+pricing:
+  transport_prices:
+    - start_date: "2023-06-01"
+      time_value: 34.38
+      price_unit: "EUR"
       time_unit: "year"
       vat_id: "reduced"
 ```
@@ -181,25 +236,26 @@ pricing:
 
 #### Example 5: Transport Price (Based on Consumption)
 
-**New capability in v0.4.0 - not available in v0.3.x:**
+**New capability in v0.5.0 - not available in v0.3.x:**
 
 ```yaml
 pricing:
   transport_prices:
     - start_date: "2024-01-01"
       quantity_value: 0.00194
-      price_unit: "€"
+      price_unit: "EUR"
       quantity_unit: "kWh"
       vat_id: "reduced"
 ```
 
-**Explanation**: Transport can now be quantity-based (€/kWh) instead of only time-based.
+**Explanation**: Transport can now be quantity-based (EUR/kWh) instead of only time-based.
 
 ---
 
 #### Example 6: Energy Taxes
+<details>
+  <summary>From v0.3.x:</summary>
 
-**Before (v0.3.x):**
 ```yaml
 pricing:
   energy_taxes:
@@ -209,8 +265,11 @@ pricing:
       base_unit: "kWh"
       vat_id: "normal"
 ```
+</details>
 
-**After (v0.4.0):**
+<details>
+  <summary>From v0.4.0:</summary>
+
 ```yaml
 pricing:
   energy_taxes:
@@ -220,14 +279,27 @@ pricing:
       quantity_unit: "kWh"
       vat_id: "normal"
 ```
+</details>
+
+**To v0.5.0:**
+```yaml
+pricing:
+  energy_taxes:
+    - start_date: "2023-06-01"
+      quantity_value: 0.00837
+      price_unit: "EUR"
+      quantity_unit: "kWh"
+      vat_id: "normal"
+```
 
 **Explanation**: Energy taxes are quantity-based, so use `quantity_value` and `quantity_unit`.
 
 ---
 
 #### Example 7: Complete Configuration Migration
+<details>
+  <summary>From v0.3.x:</summary>
 
-**Before (v0.3.x):**
 ```yaml
 pricing:
   vat:
@@ -262,8 +334,11 @@ pricing:
       base_unit: "kWh"
       vat_id: "normal"
 ```
+</details>
 
-**After (v0.4.0):**
+<details>
+  <summary>From v0.4.0:</summary>
+
 ```yaml
 pricing:
   vat:
@@ -298,9 +373,46 @@ pricing:
       price_unit: "€"       # Optional - default is €
       vat_id: "normal"
 ```
+</details>
+
+**To v0.5.0:**
+```yaml
+pricing:
+  vat:
+    - id: reduced
+      start_date: "2023-06-01"
+      value: 0.0550
+    - id: normal
+      start_date: "2023-06-01"
+      value: 0.20
+  consumption_prices:
+    - start_date: "2023-06-01"
+      quantity_value: 0.07790
+      quantity_unit: "kWh"  # Optional - default is kWh
+      price_unit: "EUR"     # Optional - default is EUR
+      vat_id: "normal"
+  subscription_prices:
+    - start_date: "2023-06-01"
+      time_value: 19.83
+      time_unit: "month"    # Optional - default is month
+      price_unit: "EUR"     # Optional - default is EUR
+      vat_id: "reduced"
+  transport_prices:
+    - start_date: "2023-06-01"
+      time_value: 34.38
+      time_unit: "year"
+      price_unit: "EUR"
+      vat_id: "reduced"
+  energy_taxes:
+    - start_date: "2023-06-01"
+      quantity_value: 0.00837
+      quantity_unit: "kWh"  # Optional - default is kWh
+      price_unit: "EUR"     # Optional - default is EUR
+      vat_id: "normal"
+```
 
 **Note**: The unit properties are optional. If omitted, the defaults are:
-- `price_unit`: € (euro)
+- `price_unit`: EUR (€, euro)
 - `quantity_unit`: kWh (kilowatt-hour)
 - `time_unit`: month
 
@@ -485,4 +597,3 @@ After migration, verify:
 ## Future Migration Guides
 
 When upgrading to future versions, additional migration guides will be documented here.
-

--- a/README.md
+++ b/README.md
@@ -225,10 +225,10 @@ The cost computation is based in gas prices defined in the configuration files.
 
 The section 'Pricing' is broken into 5 sub-sections:
 - vat: Value added tax definition.
-- consumption_prices: Gas consumption prices, typically in €/kWh (quantity-based).
-- subscription_prices: Fixed subscription prices, typically in €/month or €/year (time-based).
-- transport_prices: Transport prices, either fixed (€/month or €/year) or based on consumption (€/kWh).
-- energy_taxes: Energy taxes, typically in €/kWh (quantity-based).
+- consumption_prices: Gas consumption prices, typically in EUR/kWh (quantity-based).
+- subscription_prices: Fixed subscription prices, typically in EUR/month or EUR/year (time-based).
+- transport_prices: Transport prices, either fixed (EUR/month or EUR/year) or based on consumption (EUR/kWh).
+- energy_taxes: Energy taxes, typically in EUR/kWh (quantity-based).
 
 Below, many examples illustrates how to use pricing configuration for use cases from the simplest to the most complex.
 
@@ -238,11 +238,11 @@ Example 1: A fixed consumption price
 
 The given price applies at the given date, after and before.
 
-The default unit is € per kWh.
+The default unit is EUR per kWh.
 
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * price[€/kWh]
+cost[EUR] = quantity[kWh] * price[EUR/kWh]
 ```
 
 
@@ -250,18 +250,18 @@ cost[€] = quantity[kWh] * price[€/kWh]
 pricing:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
 ```
 
 Example 2: A fixed consumption price in another unit
 ---
 
-*price_unit* is the monetary unit (default: €).
+*price_unit* is the monetary unit (default: EUR).
 *quantity_unit* is the energy unit (default: kWh).
 
 **Formula:**
 ```math
-cost[€] = \frac{quantity[kWh] * price[¢/MWh] * converter\_factor[¢->€]} {converter\_factor[MWh->kWh]}
+cost[EUR] = \frac{quantity[kWh] * price[EUR/MWh]} {converter\_factor[MWh->kWh]}
 ```
 
 
@@ -269,8 +269,8 @@ cost[€] = \frac{quantity[kWh] * price[¢/MWh] * converter\_factor[¢->€]} {c
 pricing:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 7790.0 # Unit is now ¢/MWh.
-      price_unit: "¢"
+      quantity_value: 77.90 # Unit is now EUR/MWh.
+      price_unit: "EUR"
       quantity_unit: "MWh"
 ```
 
@@ -281,9 +281,9 @@ Example 3: Multiple prices over time
 pricing:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
     - start_date: "2024-01-01"
-      quantity_value: 0.06888 # Default unit is €/kWh.
+      quantity_value: 0.06888 # Default unit is EUR/kWh.
 ```
 
 Price is 0.07790 before 2024-01-01.
@@ -304,13 +304,13 @@ pricing:
       value: 0.20 # It is the tax rate in [0, 1.0] <==> [0% - 100%].
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
       vat_id: "normal" # Reference to the vat rate that is applied for this period.
 ```
 
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * price[€/kWh] * (1 + vat[normal])
+cost[EUR] = quantity[kWh] * price[EUR/kWh] * (1 + vat[normal])
 ```
 
 Example 5: Subscription price
@@ -331,19 +331,19 @@ pricing:
       value: 0.0550
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
       vat_id: "normal" # Reference to the vat rate that is applied for this period.
   subscription_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 19.83
-      price_unit: "€"
+      price_unit: "EUR"
       time_unit: "month"
       vat_id: "reduced"
 ```
 
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * cons\_price[€/kWh] * (1 + vat[normal]) + sub\_price * (1 + vat[reduced])
+cost[EUR] = quantity[kWh] * cons\_price[EUR/kWh] * (1 + vat[normal]) + sub\_price * (1 + vat[reduced])
 ```
 
 
@@ -363,18 +363,18 @@ pricing:
       value: 0.0550
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
       vat_id: "normal" # Reference to the vat rate that is applied for this period.
   transport_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 34.38
-      price_unit: "€"
+      price_unit: "EUR"
       time_unit: "year"
       vat_id: reduced
 ```
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * cons\_price[€/kWh] * (1 + vat[normal]) + trans\_price[€/year] * (1 + vat[reduced])
+cost[EUR] = quantity[kWh] * cons\_price[EUR/kWh] * (1 + vat[normal]) + trans\_price[EUR/year] * (1 + vat[reduced])
 ```
 
 Example 6bis: Transport price (based on consumption)
@@ -397,14 +397,14 @@ pricing:
       vat_id: "normal"
   transport_prices:
     - start_date: "2023-06-01"
-      quantity_value: 0.00194 # €/kWh
-      price_unit: "€"
+      quantity_value: 0.00194 # EUR/kWh
+      price_unit: "EUR"
       quantity_unit: "kWh"
       vat_id: reduced
 ```
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * (cons\_price[€/kWh] * (1 + vat[normal]) + quantity[kWh] * trans\_price[€/kWh] * (1 + vat[reduced]))
+cost[EUR] = quantity[kWh] * (cons\_price[EUR/kWh] * (1 + vat[normal]) + quantity[kWh] * trans\_price[EUR/kWh] * (1 + vat[reduced]))
 ```
 
 Example 7: Energy taxes
@@ -423,18 +423,18 @@ pricing:
       value: 0.0550
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
       vat_id: "normal" # Reference to the vat rate that is applied for this period.
   energy_taxes:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.00837
-      price_unit: "€"
+      price_unit: "EUR"
       quantity_unit: "kWh"
       vat_id: normal
 ```
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * (cons\_price[€/kWh] + ener\_taxes[€/kWh])* (1 + vat[normal])
+cost[EUR] = quantity[kWh] * (cons\_price[EUR/kWh] + ener\_taxes[EUR/kWh])* (1 + vat[normal])
 ```
 
 Example 8: All in one
@@ -454,7 +454,7 @@ pricing:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.07790
-      price_unit: "€"
+      price_unit: "EUR"
       quantity_unit: "kWh"
       vat_id: normal
     - start_date: "2023-07-01"
@@ -482,7 +482,7 @@ pricing:
   subscription_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 19.83
-      price_unit: "€"
+      price_unit: "EUR"
       time_unit: "month"
       vat_id: reduced
     - start_date: "2023-07-01"
@@ -490,13 +490,13 @@ pricing:
   transport_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 34.38
-      price_unit: "€"
+      price_unit: "EUR"
       time_unit: "year"
       vat_id: reduced
   energy_taxes:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.00837
-      price_unit: "€"
+      price_unit: "EUR"
       quantity_unit: "kWh"
       vat_id: normal
     - start_date: "2024-01-01"

--- a/addons/gazpar2haws/DOCS.md
+++ b/addons/gazpar2haws/DOCS.md
@@ -42,10 +42,10 @@ The cost computation is based in gas prices defined in the configuration files.
 
 The pricing configuration is broken into 5 sections:
 - vat: Value added tax definition.
-- consumption_prices: All the gas price history in €/kWh.
-- subscription_prices: The subscription prices in €/month (or year).
-- transport_prices: Transport prices, either fixed (€/month or €/year) or based on consumption (€/kWh).
-- energy_taxes: Various taxes on energy in €/kWh.
+- consumption_prices: All the gas price history in EUR/kWh.
+- subscription_prices: The subscription prices in EUR/month (or year).
+- transport_prices: Transport prices, either fixed (EUR/month or EUR/year) or based on consumption (EUR/kWh).
+- energy_taxes: Various taxes on energy in EUR/kWh.
 
 Below, many examples illustrates how to use pricing configuration for use cases from the simplest to the most complex.
 
@@ -55,37 +55,37 @@ Example 1: A fixed consumption price
 
 The given price applies at the given date, after and before.
 
-The default unit is € per kWh.
+The default unit is EUR per kWh.
 
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * price[€/kWh]
+cost[EUR] = quantity[kWh] * price[EUR/kWh]
 ```
 
 
 ```yaml
 consumption_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-    quantity_value: 0.07790 # Default unit is €/kWh.
+    quantity_value: 0.07790 # Default unit is EUR/kWh.
 ```
 
 Example 2: A fixed consumption price in another unit
 ---
 
-*price_unit* is the monetary unit (default: €).
+*price_unit* is the monetary unit (default: EUR).
 *quantity_unit* is the energy unit (default: kWh).
 
 **Formula:**
 ```math
-cost[€] = \frac{quantity[kWh] * price[¢/MWh] * converter\_factor[¢->€]} {converter\_factor[MWh->kWh]}
+cost[EUR] = \frac{quantity[kWh] * price[EUR/MWh]} {converter\_factor[MWh->kWh]}
 ```
 
 
 ```yaml
 consumption_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-    quantity_value: 7790.0 # Unit is now ¢/MWh.
-    price_unit: "¢"
+    quantity_value: 77.90 # Unit is now EUR/MWh.
+    price_unit: "EUR"
     quantity_unit: "MWh"
 ```
 
@@ -95,9 +95,9 @@ Example 3: Multiple prices over time
 ```yaml
 consumption_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-    quantity_value: 0.07790 # Default unit is €/kWh.
+    quantity_value: 0.07790 # Default unit is EUR/kWh.
   - start_date: "2024-01-01"
-    quantity_value: 0.06888 # Default unit is €/kWh.
+    quantity_value: 0.06888 # Default unit is EUR/kWh.
 ```
 
 Price is 0.07790 before 2024-01-01.
@@ -117,13 +117,13 @@ vat:
     value: 0.20 # It is the tax rate in [0, 1.0] <==> [0% - 100%].
 consumption_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-    quantity_value: 0.07790 # Default unit is €/kWh.
+    quantity_value: 0.07790 # Default unit is EUR/kWh.
     vat_id: "normal" # Reference to the vat rate that is applied for this period.
 ```
 
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * price[€/kWh] * (1 + vat[normal])
+cost[EUR] = quantity[kWh] * price[EUR/kWh] * (1 + vat[normal])
 ```
 
 Example 5: Subscription price
@@ -143,19 +143,19 @@ vat:
     value: 0.0550
 consumption_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-    quantity_value: 0.07790 # Default unit is €/kWh.
+    quantity_value: 0.07790 # Default unit is EUR/kWh.
     vat_id: "normal" # Reference to the vat rate that is applied for this period.
 subscription_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
     time_value: 19.83
-    price_unit: "€"
+    price_unit: "EUR"
     time_unit: "month"
     vat_id: "reduced"
 ```
 
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * cons\_price[€/kWh] * (1 + vat[normal]) + sub\_price * (1 + vat[reduced])
+cost[EUR] = quantity[kWh] * cons\_price[EUR/kWh] * (1 + vat[normal]) + sub\_price * (1 + vat[reduced])
 ```
 
 
@@ -174,18 +174,18 @@ vat:
     value: 0.0550
 consumption_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-    quantity_value: 0.07790 # Default unit is €/kWh.
+    quantity_value: 0.07790 # Default unit is EUR/kWh.
     vat_id: "normal" # Reference to the vat rate that is applied for this period.
 transport_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
     time_value: 34.38
-    price_unit: "€"
+    price_unit: "EUR"
     time_unit: "year"
     vat_id: reduced
 ```
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * cons\_price[€/kWh] * (1 + vat[normal]) + trans\_price[€/year] * (1 + vat[reduced])
+cost[EUR] = quantity[kWh] * cons\_price[EUR/kWh] * (1 + vat[normal]) + trans\_price[EUR/year] * (1 + vat[reduced])
 ```
 
 Example 6bis: Transport price (based on consumption)
@@ -203,19 +203,19 @@ vat:
     value: 0.0550
 consumption_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-    quantity_value: 0.07790 # Default unit is €/kWh.
+    quantity_value: 0.07790 # Default unit is EUR/kWh.
     vat_id: "normal" # Reference to the vat rate that is applied for this period.
 transport_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-    quantity_value: 0.00194 # €/kWh instead of €/year
-    price_unit: "€"
+    quantity_value: 0.00194 # EUR/kWh instead of EUR/year
+    price_unit: "EUR"
     quantity_unit: "kWh"
     vat_id: reduced
 ```
 
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * (cons\_price[€/kWh] * (1 + vat[normal]) + quantity[kWh] * trans\_price[€/kWh] * (1 + vat[reduced]))
+cost[EUR] = quantity[kWh] * (cons\_price[EUR/kWh] * (1 + vat[normal]) + quantity[kWh] * trans\_price[EUR/kWh] * (1 + vat[reduced]))
 ```
 
 Example 7: Energy taxes
@@ -233,18 +233,18 @@ vat:
     value: 0.0550
 consumption_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-    quantity_value: 0.07790 # Default unit is €/kWh.
+    quantity_value: 0.07790 # Default unit is EUR/kWh.
     vat_id: "normal" # Reference to the vat rate that is applied for this period.
 energy_taxes:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
     quantity_value: 0.00837
-    price_unit: "€"
+    price_unit: "EUR"
     quantity_unit: "kWh"
     vat_id: normal
 ```
 **Formula:**
 ```math
-cost[€] = quantity[kWh] * (cons\_price[€/kWh] + ener\_taxes[€/kWh])* (1 + vat[normal])
+cost[EUR] = quantity[kWh] * (cons\_price[EUR/kWh] + ener\_taxes[EUR/kWh])* (1 + vat[normal])
 ```
 
 Example 8: All in one
@@ -263,7 +263,7 @@ vat:
 consumption_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
     quantity_value: 0.07790
-    price_unit: "€"
+    price_unit: "EUR"
     quantity_unit: "kWh"
     vat_id: normal
   - start_date: "2023-07-01"
@@ -291,7 +291,7 @@ consumption_prices:
 subscription_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
     time_value: 19.83
-    price_unit: "€"
+    price_unit: "EUR"
     time_unit: "month"
     vat_id: reduced
   - start_date: "2023-07-01"
@@ -299,18 +299,24 @@ subscription_prices:
 transport_prices:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
     time_value: 34.38
-    price_unit: "€"
+    price_unit: "EUR"
     time_unit: "year"
     vat_id: reduced
 energy_taxes:
   - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
     quantity_value: 0.00837
-    price_unit: "€"
+    price_unit: "EUR"
     quantity_unit: "kWh"
     vat_id: normal
   - start_date: "2024-01-01"
     quantity_value: 0.01637
 ```
+
+### What are the new cost units in v0.5.0?
+
+Starting from v0.5.0, Gazpar2HAWS publishes the cost entities with a Standardized unit instead of a raw string. Units are now based on the [ISO-4217 codes](https://en.wikipedia.org/wiki/ISO_4217#Active_codes).
+
+This standardizes the montetary sensor in Home Automation.
 
 ## What's New in v0.4.0
 
@@ -341,8 +347,8 @@ This allows detailed cost analysis in Home Assistant dashboards and the Energy D
 ### Quantity-Based Transport Pricing
 
 Transport prices can now be configured either as:
-- **Fixed time-based**: `time_value` + `time_unit` (e.g., €/year)
-- **Variable quantity-based**: `quantity_value` + `quantity_unit` (e.g., €/kWh) - NEW!
+- **Fixed time-based**: `time_value` + `time_unit` (e.g., EUR/year)
+- **Variable quantity-based**: `quantity_value` + `quantity_unit` (e.g., EUR/kWh) - NEW!
 
 ### Migration from v0.3.x
 
@@ -413,7 +419,7 @@ sql:
       WHERE statistics_meta.statistic_id = 'sensor.gazpar2haws_total_cost'
       ORDER BY statistics.start DESC LIMIT 1
     column: 'state'
-    unit_of_measurement: '€'
+    unit_of_measurement: 'EUR'
     icon: mdi:cash
     device_class: monetary
     state_class: total_increasing

--- a/addons/gazpar2haws/config.yaml
+++ b/addons/gazpar2haws/config.yaml
@@ -31,7 +31,7 @@ options:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.07790
-      price_unit: "€"
+      price_unit: "EUR"
       quantity_unit: "kWh"
       vat_id: normal
     - start_date: "2023-07-01"
@@ -43,7 +43,7 @@ options:
   subscription_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 19.83
-      price_unit: "€"
+      price_unit: "EUR"
       time_unit: "month"
       vat_id: reduced
     - start_date: "2023-07-01"
@@ -51,13 +51,13 @@ options:
   transport_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 34.38
-      price_unit: "€"
+      price_unit: "EUR"
       time_unit: "year"
       vat_id: reduced
   energy_taxes:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.00837
-      price_unit: "€"
+      price_unit: "EUR"
       quantity_unit: "kWh"
       vat_id: normal
     - start_date: "2024-01-01"
@@ -80,8 +80,8 @@ schema:
   consumption_prices:
     - start_date: match(^\d{4}-\d{2}-\d{2}$) # Start date of the price. Format is "YYYY-MM-DD".
       end_date: match(^\d{4}-\d{2}-\d{2}$)? # End date of the price. Format is "YYYY-MM-DD".
-      quantity_value: float? # Price per energy unit (e.g., €/kWh).
-      price_unit: str? # Monetary unit: €, ¢.
+      quantity_value: float? # Price per energy unit (e.g., EUR/kWh).
+      price_unit: str? # Monetary unit: EUR, USD, ...
       quantity_unit: str? # Energy unit: Wh, kWh, MWh, m³, l.
       time_value: float? # Price per time unit (for composite prices).
       time_unit: str? # Time unit: day, week, month, year (for composite prices).
@@ -89,8 +89,8 @@ schema:
   subscription_prices:
     - start_date: match(^\d{4}-\d{2}-\d{2}$) # Start date of the price. Format is "YYYY-MM-DD".
       end_date: match(^\d{4}-\d{2}-\d{2}$)? # End date of the price. Format is "YYYY-MM-DD".
-      time_value: float? # Price per time unit (e.g., €/month).
-      price_unit: str? # Monetary unit: €, ¢.
+      time_value: float? # Price per time unit (e.g., EUR/month).
+      price_unit: str? # Monetary unit: EUR, USD, ...
       time_unit: str? # Time unit: day, week, month, year.
       quantity_value: float? # Price per energy unit (for composite prices).
       quantity_unit: str? # Energy unit: Wh, kWh, MWh (for composite prices).
@@ -98,17 +98,17 @@ schema:
   transport_prices:
     - start_date: match(^\d{4}-\d{2}-\d{2}$) # Start date of the price. Format is "YYYY-MM-DD".
       end_date: match(^\d{4}-\d{2}-\d{2}$)? # End date of the price. Format is "YYYY-MM-DD".
-      time_value: float? # Fixed price per time unit (e.g., €/year).
-      price_unit: str? # Monetary unit: €, ¢.
+      time_value: float? # Fixed price per time unit (e.g., EUR/year).
+      price_unit: str? # Monetary unit: EUR, USD, ...
       time_unit: str? # Time unit: day, week, month, year.
-      quantity_value: float? # Variable price per energy unit (e.g., €/kWh) - NEW in v0.4.0.
+      quantity_value: float? # Variable price per energy unit (e.g., EUR/kWh) - NEW in v0.4.0.
       quantity_unit: str? # Energy unit: Wh, kWh, MWh - NEW in v0.4.0.
       vat_id: str? # Identifier of the VAT rate.
   energy_taxes:
     - start_date: match(^\d{4}-\d{2}-\d{2}$) # Start date of the price. Format is "YYYY-MM-DD".
       end_date: match(^\d{4}-\d{2}-\d{2}$)? # End date of the price. Format is "YYYY-MM-DD".
-      quantity_value: float? # Tax per energy unit (e.g., €/kWh).
-      price_unit: str? # Monetary unit: €, ¢.
+      quantity_value: float? # Tax per energy unit (e.g., EUR/kWh).
+      price_unit: str? # Monetary unit: EUR, USD, ...
       quantity_unit: str? # Energy unit: Wh, kWh, MWh, m³, l.
       time_value: float? # Tax per time unit (for composite taxes).
       time_unit: str? # Time unit: day, week, month, year (for composite taxes).

--- a/config/configuration.template.yaml
+++ b/config/configuration.template.yaml
@@ -1,6 +1,6 @@
 logging:
   file: log/gazpar2haws.log
-  console: true  
+  console: true
   level: debug
   format: '%(asctime)s %(levelname)s [%(name)s] %(message)s'
 
@@ -32,7 +32,7 @@ pricing:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.07790  # Price per kWh (v0.4.0: renamed from 'value')
-      price_unit: "€"          # Monetary unit (v0.4.0: renamed from 'value_unit')
+      price_unit: "EUR"        # Monetary unit (v0.4.0: renamed from 'value_unit')
       quantity_unit: "kWh"     # Energy unit (v0.4.0: renamed from 'base_unit')
       vat_id: normal
     - start_date: "2023-07-01"
@@ -60,7 +60,7 @@ pricing:
   subscription_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 19.83        # Fixed price per month (v0.4.0: renamed from 'value')
-      price_unit: "€"          # Monetary unit (v0.4.0: renamed from 'value_unit')
+      price_unit: "EUR"        # Monetary unit (v0.4.0: renamed from 'value_unit')
       time_unit: "month"       # Time unit (v0.4.0: renamed from 'base_unit')
       vat_id: reduced
     - start_date: "2023-07-01"
@@ -68,7 +68,7 @@ pricing:
   transport_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 34.38        # Fixed price per year (v0.4.0: renamed from 'value')
-      price_unit: "€"          # Monetary unit (v0.4.0: renamed from 'value_unit')
+      price_unit: "EUR"        # Monetary unit (v0.4.0: renamed from 'value_unit')
       time_unit: "year"        # Time unit (v0.4.0: renamed from 'base_unit')
       vat_id: reduced
       # Alternative: quantity-based transport (new in v0.4.0)
@@ -77,7 +77,7 @@ pricing:
   energy_taxes:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.00837  # Price per kWh (v0.4.0: renamed from 'value')
-      price_unit: "€"          # Monetary unit (v0.4.0: renamed from 'value_unit')
+      price_unit: "EUR"        # Monetary unit (v0.4.0: renamed from 'value_unit')
       quantity_unit: "kWh"     # Energy unit (v0.4.0: renamed from 'base_unit')
       vat_id: normal
     - start_date: "2024-01-01"

--- a/config/configuration.yaml
+++ b/config/configuration.yaml
@@ -32,7 +32,7 @@ pricing:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.07790  # Price per kWh
-      price_unit: "€"
+      price_unit: "EUR"
       quantity_unit: "kWh"
       vat_id: normal
     - start_date: "2023-07-01"
@@ -59,22 +59,22 @@ pricing:
       quantity_value: 0.07807
   subscription_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      time_value: 19.83       # Fixed price per month
-      price_unit: "€"
+      time_value: 19.83        # Fixed price per month
+      price_unit: "EUR"
       time_unit: "month"
       vat_id: reduced
     - start_date: "2023-07-01"
       time_value: 20.36
   transport_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      time_value: 34.38       # Fixed price per year
-      price_unit: "€"
+      time_value: 34.38        # Fixed price per year
+      price_unit: "EUR"
       time_unit: "year"
       vat_id: reduced
   energy_taxes:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.00837 # Price per kWh
-      price_unit: "€"
+      quantity_value: 0.00837  # Price per kWh
+      price_unit: "EUR"
       quantity_unit: "kWh"
       vat_id: normal
     - start_date: "2024-01-01"

--- a/gazpar2haws/pricer.py
+++ b/gazpar2haws/pricer.py
@@ -565,26 +565,6 @@ class Pricer:
 
     # ----------------------------------
     @classmethod
-    def get_price_unit_convertion_factor(cls, from_price_unit: PriceUnit, to_price_unit: PriceUnit) -> float:
-
-        if from_price_unit == to_price_unit:
-            return 1.0
-
-        switcher = {
-            PriceUnit.EURO: 1.0,
-            PriceUnit.CENT: 100.0,
-        }
-
-        if from_price_unit not in switcher:
-            raise ValueError(f"Invalid 'from' price unit: {from_price_unit}")
-
-        if to_price_unit not in switcher:
-            raise ValueError(f"Invalid 'to' price unit: {to_price_unit}")
-
-        return switcher[to_price_unit] / switcher[from_price_unit]
-
-    # ----------------------------------
-    @classmethod
     def get_quantity_unit_convertion_factor(
         cls, from_quantity_unit: QuantityUnit, to_quantity_unit: QuantityUnit
     ) -> float:
@@ -634,15 +614,13 @@ class Pricer:
             and isinstance(from_unit[0], PriceUnit)
             and isinstance(from_unit[1], QuantityUnit)
         ):
-            return cls.get_price_unit_convertion_factor(
-                from_unit[0], to_unit[0]
-            ) / cls.get_quantity_unit_convertion_factor(from_unit[1], to_unit[1])
+            return 1 / cls.get_quantity_unit_convertion_factor(from_unit[1], to_unit[1])
         if isinstance(from_unit, tuple) and isinstance(from_unit[0], PriceUnit) and isinstance(from_unit[1], TimeUnit):
             if dt is None:
                 raise ValueError(
                     f"dt must not be None when from_unit {from_unit} and to_unit {to_unit} are of type Tuple[PriceUnit, TimeUnit]"
                 )
-            return cls.get_price_unit_convertion_factor(from_unit[0], to_unit[0]) / cls.get_time_unit_convertion_factor(
+            return 1 / cls.get_time_unit_convertion_factor(
                 from_unit[1], to_unit[1], dt
             )
 

--- a/tests/config/configuration.yaml
+++ b/tests/config/configuration.yaml
@@ -31,7 +31,7 @@ pricing:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.07790
       quantity_unit: "kWh"
-      price_unit: "€"
+      price_unit: "EUR"
       vat_id: normal
     - start_date: "2023-07-01"
       quantity_value: 0.05392
@@ -59,7 +59,7 @@ pricing:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 19.83
       time_unit: "month"
-      price_unit: "€"
+      price_unit: "EUR"
       vat_id: reduced
     - start_date: "2023-07-01"
       time_value: 20.36
@@ -67,13 +67,13 @@ pricing:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 34.38
       time_unit: "year"
-      price_unit: "€"
+      price_unit: "EUR"
       vat_id: reduced
   energy_taxes:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.00837
       quantity_unit: "kWh"
-      price_unit: "€"
+      price_unit: "EUR"
       vat_id: normal
     - start_date: "2024-01-01"
       quantity_value: 0.01637

--- a/tests/config/example_1.yaml
+++ b/tests/config/example_1.yaml
@@ -22,4 +22,4 @@ homeassistant:
 pricing:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.

--- a/tests/config/example_2.yaml
+++ b/tests/config/example_2.yaml
@@ -22,6 +22,6 @@ homeassistant:
 pricing:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 7790.0 # Unit is now ¢/MWh.
+      quantity_value: 77.900 # Unit is now EUR/MWh.
       quantity_unit: "MWh"
-      price_unit: "¢"
+      price_unit: "EUR"

--- a/tests/config/example_3.yaml
+++ b/tests/config/example_3.yaml
@@ -22,6 +22,6 @@ homeassistant:
 pricing:
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
     - start_date: "2024-01-01"
-      quantity_value: 0.06888 # Default unit is €/kWh.
+      quantity_value: 0.06888 # Default unit is EUR/kWh.

--- a/tests/config/example_4.yaml
+++ b/tests/config/example_4.yaml
@@ -26,5 +26,5 @@ pricing:
       value: 0.20 # It is the tax rate in [0, 1.0] <==> [0% - 100%].
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
       vat_id: "normal" # Reference to the vat rate that is applied for this period.

--- a/tests/config/example_5.yaml
+++ b/tests/config/example_5.yaml
@@ -29,11 +29,11 @@ pricing:
       value: 0.0550
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
       vat_id: "normal" # Reference to the vat rate that is applied for this period.
   subscription_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 19.83
       time_unit: "month"
-      price_unit: "€"
+      price_unit: "EUR"
       vat_id: "reduced"

--- a/tests/config/example_6.yaml
+++ b/tests/config/example_6.yaml
@@ -29,11 +29,11 @@ pricing:
       value: 0.0550
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
       vat_id: "normal" # Reference to the vat rate that is applied for this period.
   transport_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       time_value: 34.38
       time_unit: "year"
-      price_unit: "€"
+      price_unit: "EUR"
       vat_id: reduced

--- a/tests/config/example_6bis.yaml
+++ b/tests/config/example_6bis.yaml
@@ -29,11 +29,11 @@ pricing:
       value: 0.0550
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
       vat_id: "normal" # Reference to the vat rate that is applied for this period.
   transport_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.00194
       quantity_unit: "kWh"
-      price_unit: "€"
+      price_unit: "EUR"
       vat_id: reduced

--- a/tests/config/example_7.yaml
+++ b/tests/config/example_7.yaml
@@ -29,11 +29,11 @@ pricing:
       value: 0.0550
   consumption_prices:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
-      quantity_value: 0.07790 # Default unit is €/kWh.
+      quantity_value: 0.07790 # Default unit is EUR/kWh.
       vat_id: "normal" # Reference to the vat rate that is applied for this period.
   energy_taxes:
     - start_date: "2023-06-01" # Date of the price. Format is "YYYY-MM-DD".
       quantity_value: 0.00837
       quantity_unit: "kWh"
-      price_unit: "€"
+      price_unit: "EUR"
       vat_id: normal

--- a/tests/test_gazpar.py
+++ b/tests/test_gazpar.py
@@ -99,7 +99,7 @@ class TestGazpar:
             daily_history, pygazpar.PropertyName.ENERGY.value, start_date, end_date
         )
 
-        await gazpar.publish_date_array("sensor.gazpar2haws_test", "gazpar2haws_test", "kWh", energy_array, 0)
+        await gazpar.publish_date_array("sensor.gazpar2haws_test", "gazpar2haws_test", "energy", "kWh", energy_array, 0)
 
         await self._haws.disconnect()
 
@@ -135,18 +135,19 @@ class TestGazpar:
         if energy_array is not None:
             pricer = Pricer(self._pricing_config)
 
-            cost_breakdown = pricer.compute(quantities, PriceUnit.EURO)
+            cost_breakdown = pricer.compute(quantities, PriceUnit.EUR)
             cost_array = cost_breakdown.total
         else:
             cost_array = None
 
         await gazpar.publish_date_array(
-            "sensor.gazpar2haws_energy_test", "gazpar2haws_energy_test", "kWh", energy_array, 0
+            "sensor.gazpar2haws_energy_test", "gazpar2haws_energy_test", "energy", "kWh", energy_array, 0
         )
 
         await gazpar.publish_date_array(
             "sensor.gazpar2haws_cost_test",
             "gazpar2haws_cost_test",
+            None,
             cost_array.value_unit,
             cost_array.value_array,
             0,

--- a/tests/test_haws.py
+++ b/tests/test_haws.py
@@ -7,6 +7,7 @@ import pytest
 
 from gazpar2haws import config_utils
 from gazpar2haws.haws import HomeAssistantWS
+from gazpar2haws.model import PriceUnit
 
 # See WebSocket source code here: https://git.informatik.uni-kl.de/s_menne19/hassio-core/-/blob/fix-tests-assist/homeassistant/components/recorder/websocket_api.py
 
@@ -98,7 +99,7 @@ class TestHomeAssistantWS:
             {"start": "2020-12-16T00:00:00+00:00", "state": 300.0, "sum": 300.0},
         ]
 
-        await self._haws.import_statistics("sensor.gazpar2haws_volume", "recorder", "test", "m³", statistics)
+        await self._haws.import_statistics("sensor.gazpar2haws_volume", "recorder", "test", "volume", "m³", statistics)
 
         await self._haws.disconnect()
 
@@ -118,7 +119,34 @@ class TestHomeAssistantWS:
     # ----------------------------------
     # @pytest.mark.skip(reason="Requires Home Assistant server")
     @pytest.mark.asyncio
-    async def test_migrate_statistic_old_sensor_not_exists(self):
+    async def test_update_statistics_metadata(self):
+
+        await self._haws.connect()
+
+        await self._haws.update_statistics_metadata(
+            "sensor.gazpar2haws_energy",
+            "energy",
+            "kWh",
+        )
+
+        await self._haws.update_statistics_metadata(
+            "sensor.gazpar2haws_cost",
+            None,
+            PriceUnit.EUR,
+        )
+
+        await self._haws.update_statistics_metadata(
+            "sensor.gazpar2haws_volume",
+            "volume",
+            "m³",
+        )
+
+        await self._haws.disconnect()
+
+    # ----------------------------------
+    # @pytest.mark.skip(reason="Requires Home Assistant server")
+    @pytest.mark.asyncio
+    async def test_migrate_statistic_from_v_0_3_x_old_sensor_not_exists(self):
         """Test migration when old sensor doesn't exist - should skip gracefully."""
 
         await self._haws.connect()
@@ -126,11 +154,12 @@ class TestHomeAssistantWS:
         # Migrate from non-existent old sensor - should return True (success/skip)
         from datetime import date
 
-        result = await self._haws.migrate_statistic(
+        result = await self._haws.migrate_statistic_from_v_0_3_x(
             "sensor.gazpar2haws_nonexistent",
             "sensor.gazpar2haws_total_cost",
             "Gazpar2HAWS Total Cost",
-            "€",
+            None,
+            PriceUnit.EUR,
             timezone="Europe/Paris",
             as_of_date=date.today(),
         )
@@ -142,7 +171,7 @@ class TestHomeAssistantWS:
     # ----------------------------------
     # @pytest.mark.skip(reason="Requires Home Assistant server")
     @pytest.mark.asyncio
-    async def test_migrate_statistic_both_sensors_exist(self):
+    async def test_migrate_statistic_from_v_0_3_x_both_sensors_exist(self):
         """Test migration when both old and new sensors exist - should skip to prevent data loss."""
 
         await self._haws.connect()
@@ -162,9 +191,9 @@ class TestHomeAssistantWS:
             {"start": "2024-12-16T00:00:00+00:00", "state": 300.0, "sum": 300.0},
         ]
 
-        await self._haws.import_statistics("sensor.gazpar2haws_cost", "recorder", "Old Cost", "€", old_statistics)
+        await self._haws.import_statistics("sensor.gazpar2haws_cost", "recorder", "Old Cost", None, PriceUnit.EUR, old_statistics)
         await self._haws.import_statistics(
-            "sensor.gazpar2haws_total_cost", "recorder", "New Total Cost", "€", new_statistics
+            "sensor.gazpar2haws_total_cost", "recorder", "New Total Cost", None, PriceUnit.EUR, new_statistics
         )
 
         # Wait a moment for Home Assistant to process the import
@@ -173,11 +202,12 @@ class TestHomeAssistantWS:
         # Attempt migration when both exist - should return True (skip with warning)
         from datetime import date
 
-        result = await self._haws.migrate_statistic(
+        result = await self._haws.migrate_statistic_from_v_0_3_x(
             "sensor.gazpar2haws_cost",
             "sensor.gazpar2haws_total_cost",
             "Gazpar2HAWS Total Cost",
-            "€",
+            None,
+            PriceUnit.EUR,
             timezone="Europe/Paris",
             as_of_date=date(2024, 12, 31),
         )
@@ -205,7 +235,7 @@ class TestHomeAssistantWS:
     # ----------------------------------
     # @pytest.mark.skip(reason="Requires Home Assistant server")
     @pytest.mark.asyncio
-    async def test_migrate_statistic_successful_migration(self):
+    async def test_migrate_statistic_from_v_0_3_x_successful_migration(self):
         """Test successful migration of data from old to new sensor."""
 
         await self._haws.connect()
@@ -226,7 +256,7 @@ class TestHomeAssistantWS:
         ]
 
         await self._haws.import_statistics(
-            "sensor.gazpar2haws_cost_migrate_test", "recorder", "Old Cost", "€", old_statistics
+            "sensor.gazpar2haws_cost_migrate_test", "recorder", "Old Cost", None, PriceUnit.EUR, old_statistics
         )
 
         # Wait a moment for Home Assistant to process the import
@@ -235,11 +265,12 @@ class TestHomeAssistantWS:
         # Perform migration - should succeed and copy all data
         from datetime import date
 
-        result = await self._haws.migrate_statistic(
+        result = await self._haws.migrate_statistic_from_v_0_3_x(
             "sensor.gazpar2haws_cost_migrate_test",
             "sensor.gazpar2haws_total_cost_migrate_test",
             "Gazpar2HAWS Total Cost",
-            "€",
+            None,
+            PriceUnit.EUR,
             timezone="Europe/Paris",
             as_of_date=date(2024, 12, 31),
         )
@@ -268,5 +299,202 @@ class TestHomeAssistantWS:
         await self._haws.clear_statistics(
             ["sensor.gazpar2haws_cost_migrate_test", "sensor.gazpar2haws_total_cost_migrate_test"]
         )
+
+        await self._haws.disconnect()
+
+    # ----------------------------------
+    # @pytest.mark.skip(reason="Requires Home Assistant server")
+    @pytest.mark.asyncio
+    async def test_migrate_statistics_from_v_0_4_x_successful_migration(self):
+        """Test successful migration of data from old to new units."""
+
+        await self._haws.connect()
+
+        # Clear any existing data from previous tests
+        try:
+            await self._haws.clear_statistics(
+                ["sensor.gazpar2haws_consumption_cost_migrate_test", "sensor.gazpar2haws_subscription_cost_migrate_test"]
+            )
+        except Exception:  # pylint: disable=broad-except
+            pass  # OK if sensors don't exist yet
+
+        # Create old sensor with historical data
+        consumption_cost_statistics = [
+            {"start": "2024-12-14T00:00:00+00:00", "state": 100.0, "sum": 100.0},
+            {"start": "2024-12-15T00:00:00+00:00", "state": 200.0, "sum": 200.0},
+            {"start": "2024-12-16T00:00:00+00:00", "state": 300.0, "sum": 300.0},
+        ]
+
+        subscription_cost_statistics = [
+            {"start": "2024-12-14T00:00:00+00:00", "state": 100.0, "sum": 100.0},
+            {"start": "2024-12-15T00:00:00+00:00", "state": 200.0, "sum": 200.0},
+            {"start": "2024-12-16T00:00:00+00:00", "state": 300.0, "sum": 300.0},
+        ]
+
+        sensors = {
+            "sensor.gazpar2haws_consumption_cost_migrate_test": consumption_cost_statistics,
+            "sensor.gazpar2haws_subscription_cost_migrate_test": subscription_cost_statistics,
+        }
+
+        for sensor_id, statistics in sensors.items():
+            await self._haws.import_statistics(sensor_id, "recorder", "Old " + sensor_id.split("_")[-1], None, "€", statistics)
+
+        # Wait a moment for Home Assistant to process the import
+        await asyncio.sleep(1)
+
+        # Perform migration - should succeed and copy all data
+        from datetime import date
+
+        result = await self._haws.migrate_statistics_from_v_0_4_x(
+            entity_ids=[sensor for sensor in sensors.keys()],
+            unit_class=None,
+            unit_of_measurement=PriceUnit.EUR,
+            timezone="Europe/Paris",
+            as_of_date=date(2024, 12, 31),
+        )
+
+        assert result is True
+
+        # Wait a moment for Home Assistant to process the import
+        await asyncio.sleep(1)
+
+        # Verify new sensor has all the data from old sensor
+        import pytz
+
+        tz = pytz.timezone("Europe/Paris")
+        start = tz.localize(datetime(2024, 12, 1))
+        end = tz.localize(datetime(2024, 12, 31))
+        new_stats = await self._haws.statistics_during_period(list(sensors.keys()), start, end)
+
+        for sensor_id in sensors.keys():
+            assert sensor_id in new_stats
+            assert len(new_stats[sensor_id]) == 3
+            assert new_stats[sensor_id][0]["sum"] == 100.0
+            assert new_stats[sensor_id][1]["sum"] == 200.0
+            assert new_stats[sensor_id][2]["sum"] == 300.0
+
+        await self._haws.disconnect()
+
+    # ----------------------------------
+    # @pytest.mark.skip(reason="Requires Home Assistant server")
+    @pytest.mark.asyncio
+    async def test_migrate_statistics_from_v_0_4_x_with_cents_unit(self):
+        """Test successful migration of data from old to new units with cents unit."""
+
+        await self._haws.connect()
+
+        # Clear any existing data from previous tests
+        try:
+            await self._haws.clear_statistics(
+                ["sensor.gazpar2haws_transport_cost_migrate_test", "sensor.gazpar2haws_energy_taxes_cost_migrate_test"]
+            )
+        except Exception:  # pylint: disable=broad-except
+            pass  # OK if sensors don't exist yet
+
+        # Create old sensor with historical data
+
+        transport_cost_statistics = [
+            {"start": "2024-12-14T00:00:00+00:00", "state": 100.0, "sum": 100.0},
+            {"start": "2024-12-15T00:00:00+00:00", "state": 200.0, "sum": 200.0},
+            {"start": "2024-12-16T00:00:00+00:00", "state": 300.0, "sum": 300.0},
+        ]
+
+        energy_taxes_cost_statistics = [
+            {"start": "2024-12-14T00:00:00+00:00", "state": 100.0, "sum": 100.0},
+            {"start": "2024-12-15T00:00:00+00:00", "state": 200.0, "sum": 200.0},
+            {"start": "2024-12-16T00:00:00+00:00", "state": 300.0, "sum": 300.0},
+        ]
+
+        sensors = {
+            "sensor.gazpar2haws_transport_cost_migrate_test": transport_cost_statistics,
+            "sensor.gazpar2haws_energy_taxes_cost_migrate_test": energy_taxes_cost_statistics,
+        }
+
+        for sensor_id, statistics in sensors.items():
+            await self._haws.import_statistics(sensor_id, "recorder", "Old " + sensor_id.split("_")[-1], None, "¢", statistics)
+
+        # Wait a moment for Home Assistant to process the import
+        await asyncio.sleep(1)
+
+        # Perform migration - should succeed and copy all data
+        from datetime import date
+
+        result = await self._haws.migrate_statistics_from_v_0_4_x(
+            entity_ids=[sensor for sensor in sensors.keys()],
+            unit_class=None,
+            unit_of_measurement=PriceUnit.EUR,
+            timezone="Europe/Paris",
+            as_of_date=date(2024, 12, 31),
+        )
+
+        assert result is True
+
+        # Wait a moment for Home Assistant to process the import
+        await asyncio.sleep(1)
+
+        # Verify new sensor has all the data from old sensor
+        import pytz
+
+        tz = pytz.timezone("Europe/Paris")
+        start = tz.localize(datetime(2024, 12, 1))
+        end = tz.localize(datetime(2024, 12, 31))
+        new_stats = await self._haws.statistics_during_period(list(sensors.keys()), start, end)
+
+        for sensor_id in sensors.keys():
+            assert sensor_id in new_stats
+            assert len(new_stats[sensor_id]) == 3
+            assert new_stats[sensor_id][0]["sum"] == 10000.0
+            assert new_stats[sensor_id][1]["sum"] == 20000.0
+            assert new_stats[sensor_id][2]["sum"] == 30000.0
+
+        await self._haws.disconnect()
+
+
+    # ----------------------------------
+    # @pytest.mark.skip(reason="Requires Home Assistant server")
+    @pytest.mark.asyncio
+    async def test_migrate_statistics_from_v_0_4_x_no_old_data(self):
+        """Test successful migration of data from old to new units with no old data."""
+
+        await self._haws.connect()
+
+        # Clear any existing data from previous tests
+        try:
+            await self._haws.clear_statistics(
+                ["sensor.gazpar2haws_consumption_cost_migrate_test", "sensor.gazpar2haws_subscription_cost_migrate_test"]
+            )
+        except Exception:  # pylint: disable=broad-except
+            pass  # OK if sensors don't exist yet
+
+        # Wait a moment for Home Assistant to process the import
+        await asyncio.sleep(1)
+
+        # Perform migration - should succeed and copy all data
+        from datetime import date
+
+        result = await self._haws.migrate_statistics_from_v_0_4_x(
+            entity_ids=["sensor.gazpar2haws_consumption_cost_migrate_test", "sensor.gazpar2haws_subscription_cost_migrate_test"],
+            unit_class=None,
+            unit_of_measurement=PriceUnit.EUR,
+            timezone="Europe/Paris",
+            as_of_date=date(2024, 12, 31),
+        )
+
+        assert result is True
+
+        # Wait a moment for Home Assistant to process the import
+        await asyncio.sleep(1)
+
+        # Verify new sensor has all the data from old sensor
+        import pytz
+
+        tz = pytz.timezone("Europe/Paris")
+        start = tz.localize(datetime(2024, 12, 1))
+        end = tz.localize(datetime(2024, 12, 31))
+
+        new_stats = await self._haws.statistics_during_period(["sensor.gazpar2haws_consumption_cost_migrate_test", "sensor.gazpar2haws_subscription_cost_migrate_test"], start, end)
+
+        for sensor_id in ["sensor.gazpar2haws_consumption_cost_migrate_test", "sensor.gazpar2haws_subscription_cost_migrate_test"]:
+            assert sensor_id not in new_stats
 
         await self._haws.disconnect()

--- a/tests/test_pricer.py
+++ b/tests/test_pricer.py
@@ -45,7 +45,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=self._pricer.pricing_data().consumption_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.DAY,
         )
@@ -65,7 +65,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=self._pricer.pricing_data().consumption_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.DAY,
         )
@@ -85,7 +85,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=self._pricer.pricing_data().consumption_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.DAY,
         )
@@ -104,7 +104,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=self._pricer.pricing_data().consumption_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.DAY,
         )
@@ -123,7 +123,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=self._pricer.pricing_data().consumption_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.DAY,
         )
@@ -143,7 +143,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=self._pricer.pricing_data().consumption_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.DAY,
         )
@@ -162,7 +162,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=self._pricer.pricing_data().consumption_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.DAY,
         )
@@ -214,14 +214,6 @@ class TestPricer:  # pylint: disable=R0904
         )
 
     # ----------------------------------
-    def test_get_price_unit_convertion_factor(self):
-
-        assert math.isclose(
-            Pricer.get_price_unit_convertion_factor(PriceUnit.EURO, PriceUnit.CENT), 100.0, rel_tol=1e-6
-        )
-        assert math.isclose(Pricer.get_price_unit_convertion_factor(PriceUnit.CENT, PriceUnit.EURO), 0.01, rel_tol=1e-6)
-
-    # ----------------------------------
     def test_get_quantity_unit_convertion_factor(self):
 
         assert math.isclose(
@@ -248,26 +240,17 @@ class TestPricer:  # pylint: disable=R0904
 
         dt = date(2023, 8, 20)
 
-        euro_per_kwh = (PriceUnit.EURO, QuantityUnit.KWH)
-        cent_per_kwh = (PriceUnit.CENT, QuantityUnit.KWH)
-        euro_per_mwh = (PriceUnit.EURO, QuantityUnit.MWH)
-        cent_per_mwh = (PriceUnit.CENT, QuantityUnit.MWH)
+        euro_per_kwh = (PriceUnit.EUR, QuantityUnit.KWH)
+        euro_per_mwh = (PriceUnit.EUR, QuantityUnit.MWH)
 
-        euro_per_year = (PriceUnit.EURO, TimeUnit.YEAR)
-        cent_per_year = (PriceUnit.CENT, TimeUnit.YEAR)
-        euro_per_month = (PriceUnit.EURO, TimeUnit.MONTH)
-        cent_per_month = (PriceUnit.CENT, TimeUnit.MONTH)
-        euro_per_day = (PriceUnit.EURO, TimeUnit.DAY)
-        cent_per_day = (PriceUnit.CENT, TimeUnit.DAY)
+        euro_per_year = (PriceUnit.EUR, TimeUnit.YEAR)
+        euro_per_month = (PriceUnit.EUR, TimeUnit.MONTH)
+        euro_per_day = (PriceUnit.EUR, TimeUnit.DAY)
 
         assert math.isclose(Pricer.get_convertion_factor(euro_per_kwh, euro_per_kwh), 1.0, rel_tol=1e-6)
-        assert math.isclose(Pricer.get_convertion_factor(euro_per_kwh, cent_per_kwh), 100.0, rel_tol=1e-6)
-        assert math.isclose(Pricer.get_convertion_factor(cent_per_kwh, euro_per_kwh), 0.01, rel_tol=1e-6)
 
         assert math.isclose(Pricer.get_convertion_factor(euro_per_kwh, euro_per_mwh), 1000.0, rel_tol=1e-6)
         assert math.isclose(Pricer.get_convertion_factor(euro_per_mwh, euro_per_kwh), 0.001, rel_tol=1e-6)
-
-        assert math.isclose(Pricer.get_convertion_factor(cent_per_mwh, euro_per_kwh), 0.00001, rel_tol=1e-6)
 
         assert math.isclose(Pricer.get_convertion_factor(euro_per_year, euro_per_month, dt), 1 / 12, rel_tol=1e-6)
         assert math.isclose(Pricer.get_convertion_factor(euro_per_month, euro_per_year, dt), 12, rel_tol=1e-6)
@@ -276,25 +259,20 @@ class TestPricer:  # pylint: disable=R0904
         assert math.isclose(Pricer.get_convertion_factor(euro_per_month, euro_per_day, dt), 1 / 31, rel_tol=1e-6)
         assert math.isclose(Pricer.get_convertion_factor(euro_per_day, euro_per_month, dt), 31, rel_tol=1e-6)
 
-        assert math.isclose(Pricer.get_convertion_factor(cent_per_year, cent_per_month, dt), 1 / 12, rel_tol=1e-6)
-        assert math.isclose(Pricer.get_convertion_factor(cent_per_month, cent_per_year, dt), 12, rel_tol=1e-6)
-        assert math.isclose(Pricer.get_convertion_factor(cent_per_year, cent_per_day, dt), 1 / 365, rel_tol=1e-6)
-        assert math.isclose(Pricer.get_convertion_factor(cent_per_day, cent_per_year, dt), 365, rel_tol=1e-6)
-
     # ----------------------------------
     def test_convert(self):
 
         consumption_prices = self._pricer.pricing_data().consumption_prices
 
-        converted_prices = Pricer.convert(consumption_prices, (PriceUnit.CENT, QuantityUnit.WH, TimeUnit.DAY))
+        converted_prices = Pricer.convert(consumption_prices, (PriceUnit.EUR, QuantityUnit.WH, TimeUnit.DAY))
 
         for i in range(len(consumption_prices) - 1):
             consumption_price = consumption_prices[i]
             converted_price = converted_prices[i]
 
-            assert converted_price.price_unit == PriceUnit.CENT
+            assert converted_price.price_unit == PriceUnit.EUR
             assert converted_price.quantity_unit == QuantityUnit.WH
-            assert converted_price.quantity_value == 0.1 * consumption_price.quantity_value
+            assert converted_price.quantity_value == 0.001 * consumption_price.quantity_value
 
     # ----------------------------------
     def _create_quantities(
@@ -320,7 +298,7 @@ class TestPricer:  # pylint: disable=R0904
 
         quantities = self._create_quantities(start_date, end_date, 1.0, QuantityUnit.KWH)
 
-        cost_breakdown = self._pricer.compute(quantities, PriceUnit.EURO)
+        cost_breakdown = self._pricer.compute(quantities, PriceUnit.EUR)
 
         # Verify breakdown structure
         assert cost_breakdown.consumption is not None
@@ -332,7 +310,7 @@ class TestPricer:  # pylint: disable=R0904
         # Verify total cost array
         assert cost_breakdown.total.start_date == start_date
         assert cost_breakdown.total.end_date == end_date
-        assert cost_breakdown.total.value_unit == "€"
+        assert cost_breakdown.total.value_unit == PriceUnit.EUR
         assert len(cost_breakdown.total.value_array) == 6
         assert math.isclose(cost_breakdown.total.value_array[start_date], 0.86912910, rel_tol=1e-6)
         assert math.isclose(cost_breakdown.total.value_array[end_date], 0.86912910, rel_tol=1e-6)
@@ -354,7 +332,7 @@ class TestPricer:  # pylint: disable=R0904
         quantities = self._create_quantities(single_date, single_date, quantity, unit)
 
         # Compute the cost (returns breakdown with detailed components)
-        cost_breakdown = pricer.compute(quantities, PriceUnit.EURO)
+        cost_breakdown = pricer.compute(quantities, PriceUnit.EUR)
 
         if cost_breakdown.total.value_array is not None:
             return cost_breakdown.total.value_array[single_date]
@@ -495,8 +473,8 @@ class TestPricer:  # pylint: disable=R0904
         """Test with transport_prices having quantity_value instead of time_value.
 
         This config has:
-        - consumption_prices: 0.07790 €/kWh with normal VAT (20%)
-        - transport_prices: 0.00194 €/kWh with reduced VAT (5.5%)
+        - consumption_prices: 0.07790 EUR/kWh with normal VAT (20%)
+        - transport_prices: 0.00194 EUR/kWh with reduced VAT (5.5%)
 
         The new implementation correctly handles transport as a quantity-based price.
         """
@@ -573,20 +551,20 @@ class TestPricer:  # pylint: disable=R0904
             CompositePriceValue(
                 start_date=date(2023, 6, 1),
                 end_date=date(2023, 6, 3),
-                price_unit=PriceUnit.EURO,
-                quantity_value=0.08,  # €/kWh
+                price_unit=PriceUnit.EUR,
+                quantity_value=0.08,  # EUR/kWh
                 quantity_unit=QuantityUnit.KWH,
-                time_value=20.0,  # €/month
+                time_value=20.0,  # EUR/month
                 time_unit=TimeUnit.MONTH,
                 vat_id="normal",
             ),
             CompositePriceValue(
                 start_date=date(2023, 6, 3),
                 end_date=date(2023, 6, 10),
-                price_unit=PriceUnit.EURO,
-                quantity_value=0.07,  # €/kWh (changed)
+                price_unit=PriceUnit.EUR,
+                quantity_value=0.07,  # EUR/kWh (changed)
                 quantity_unit=QuantityUnit.KWH,
-                time_value=25.0,  # €/month (changed)
+                time_value=25.0,  # EUR/month (changed)
                 time_unit=TimeUnit.MONTH,
                 vat_id="normal",
             ),
@@ -598,7 +576,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=composite_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.MONTH,
         )
@@ -607,7 +585,7 @@ class TestPricer:  # pylint: disable=R0904
         assert composite_price_array is not None
         assert composite_price_array.start_date == start_date
         assert composite_price_array.end_date == end_date
-        assert composite_price_array.price_unit == PriceUnit.EURO
+        assert composite_price_array.price_unit == PriceUnit.EUR
         assert composite_price_array.quantity_unit == QuantityUnit.KWH
         assert composite_price_array.time_unit == TimeUnit.MONTH
         assert composite_price_array.vat_id == "normal"
@@ -648,8 +626,8 @@ class TestPricer:  # pylint: disable=R0904
         composite_prices = [
             CompositePriceValue(
                 start_date=date(2023, 7, 1),
-                price_unit=PriceUnit.EURO,
-                quantity_value=0.05,  # €/kWh
+                price_unit=PriceUnit.EUR,
+                quantity_value=0.05,  # EUR/kWh
                 quantity_unit=QuantityUnit.KWH,
                 time_value=None,  # No time component
                 time_unit=TimeUnit.MONTH,
@@ -662,7 +640,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=composite_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.MONTH,
         )
@@ -690,10 +668,10 @@ class TestPricer:  # pylint: disable=R0904
         composite_prices = [
             CompositePriceValue(
                 start_date=date(2023, 7, 1),
-                price_unit=PriceUnit.EURO,
+                price_unit=PriceUnit.EUR,
                 quantity_value=None,  # No quantity component
                 quantity_unit=QuantityUnit.KWH,
-                time_value=15.0,  # €/month
+                time_value=15.0,  # EUR/month
                 time_unit=TimeUnit.MONTH,
                 vat_id="reduced",
             ),
@@ -704,7 +682,7 @@ class TestPricer:  # pylint: disable=R0904
             end_date=end_date,
             composite_prices=composite_prices,
             vat_rate_array_by_id=vat_rate_array_by_id,
-            target_price_unit=PriceUnit.EURO,
+            target_price_unit=PriceUnit.EUR,
             target_quantity_unit=QuantityUnit.KWH,
             target_time_unit=TimeUnit.MONTH,
         )


### PR DESCRIPTION
Hello,

Based on the Home Assistant documentation, sensors may have various device classes: [ref](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes).  
The unit for each of them are recommended, monetary sensors should use [the ISO 4217 codes](https://en.wikipedia.org/wiki/ISO_4217#Active_codes).

This PR replaces all occurrences of the `€` symbols to `EUR` (and `¢` to `EUR` after updating the values).
This PR deprecates the usage of `€` and `¢` cost units but remains compatible with previous configuration emitting a warning log when needed.
It automatically migrates from `v0.3.x` to `v0.5.0`.
It automatically migrates from `v0.4.x` to `v0.5.0`.