### PR TITLE
fix(haws) Specify fields on statistics import

### DIFF
--- a/gazpar2haws/gazpar.py
+++ b/gazpar2haws/gazpar.py
@@ -107,6 +107,7 @@ class Gazpar:
                     old_entity_id=old_total_cost_sensor_name,
                     new_entity_id=total_cost_sensor_name,
                     new_name="Gazpar2HAWS Total Cost",
+                    unit_class=None,
                     unit_of_measurement="€",
                     timezone=self._timezone,
                     as_of_date=as_of_date,
@@ -223,6 +224,7 @@ class Gazpar:
             await self.publish_date_array(
                 volume_sensor_name,
                 "Gazpar2HAWS Volume",
+                "volume",
                 "m³",
                 volume_array,
                 last_date_and_value_by_sensor[volume_sensor_name][1],
@@ -234,6 +236,7 @@ class Gazpar:
             await self.publish_date_array(
                 energy_sensor_name,
                 "Gazpar2HAWS Energy",
+                "energy",
                 "kWh",
                 energy_array[energy_start_date : end_date + timedelta(days=1)],
                 last_date_and_value_by_sensor[energy_sensor_name][1],
@@ -267,6 +270,7 @@ class Gazpar:
             await self.publish_date_array(
                 consumption_cost_sensor_name,
                 "Gazpar2HAWS Consumption Cost",
+                None,
                 cost_breakdown.consumption.value_unit,
                 cost_breakdown.consumption.value_array,
                 last_date_and_value_by_sensor[consumption_cost_sensor_name][1],
@@ -276,6 +280,7 @@ class Gazpar:
             await self.publish_date_array(
                 subscription_cost_sensor_name,
                 "Gazpar2HAWS Subscription Cost",
+                None,
                 cost_breakdown.subscription.value_unit,
                 cost_breakdown.subscription.value_array,
                 last_date_and_value_by_sensor[subscription_cost_sensor_name][1],
@@ -285,6 +290,7 @@ class Gazpar:
             await self.publish_date_array(
                 transport_cost_sensor_name,
                 "Gazpar2HAWS Transport Cost",
+                None,
                 cost_breakdown.transport.value_unit,
                 cost_breakdown.transport.value_array,
                 last_date_and_value_by_sensor[transport_cost_sensor_name][1],
@@ -294,6 +300,7 @@ class Gazpar:
             await self.publish_date_array(
                 energy_taxes_cost_sensor_name,
                 "Gazpar2HAWS Energy Taxes Cost",
+                None,
                 cost_breakdown.energy_taxes.value_unit,
                 cost_breakdown.energy_taxes.value_array,
                 last_date_and_value_by_sensor[energy_taxes_cost_sensor_name][1],
@@ -303,6 +310,7 @@ class Gazpar:
             await self.publish_date_array(
                 total_cost_sensor_name,
                 "Gazpar2HAWS Total Cost",
+                None,
                 cost_breakdown.total.value_unit,
                 cost_breakdown.total.value_array,
                 last_date_and_value_by_sensor[total_cost_sensor_name][1],
@@ -387,6 +395,7 @@ class Gazpar:
         self,
         entity_id: str,
         entity_name: str,
+        unit_class: str | None,
         unit_of_measurement: str,
         date_array: DateArray,
         initial_value: float,
@@ -409,7 +418,7 @@ class Gazpar:
         # Publish statistics to Home Assistant
         try:
             await self._homeassistant.import_statistics(
-                entity_id, "recorder", entity_name, unit_of_measurement, statistics
+                entity_id, "recorder", entity_name, unit_class, unit_of_measurement, statistics
             )
         except Exception:
             Logger.warning(f"Error while importing statistics to Home Assistant: {traceback.format_exc()}")

--- a/gazpar2haws/haws.py
+++ b/gazpar2haws/haws.py
@@ -186,6 +186,7 @@ class HomeAssistantWS:
         entity_id: str,
         source: str,
         name: str,
+        unit_class: str,
         unit_of_measurement: str,
         statistics: list[dict],
     ):
@@ -201,10 +202,12 @@ class HomeAssistantWS:
             "type": "recorder/import_statistics",
             "metadata": {
                 "has_mean": False,
+                "mean_type": 0,
                 "has_sum": True,
                 "statistic_id": entity_id,
                 "source": source,
                 "name": name,
+                "unit_class": unit_class,
                 "unit_of_measurement": unit_of_measurement,
             },
             "stats": statistics,
@@ -235,6 +238,7 @@ class HomeAssistantWS:
         old_entity_id: str,
         new_entity_id: str,
         new_name: str,
+        unit_class: str | None,
         unit_of_measurement: str,
         timezone: str,
         as_of_date: date,
@@ -252,6 +256,7 @@ class HomeAssistantWS:
             old_entity_id: Source sensor ID (e.g., sensor.gazpar2haws_cost)
             new_entity_id: Target sensor ID (e.g., sensor.gazpar2haws_total_cost)
             new_name: Display name for the new sensor
+            unit_class: Device class for the new sensor (see https://developers.home-assistant.io/docs/core/entity/sensor/#device-class)
             unit_of_measurement: Unit for the new sensor (e.g., "€")
             timezone: Timezone string (e.g., "Europe/Paris")
             as_of_date: Latest date to query for migration
@@ -320,6 +325,7 @@ class HomeAssistantWS:
                 entity_id=new_entity_id,
                 source="recorder",
                 name=new_name,
+                unit_class=unit_class,
                 unit_of_measurement=unit_of_measurement,
                 statistics=converted_statistics,
             )

--- a/tests/test_gazpar.py
+++ b/tests/test_gazpar.py
@@ -99,7 +99,7 @@ class TestGazpar:
             daily_history, pygazpar.PropertyName.ENERGY.value, start_date, end_date
         )
 
-        await gazpar.publish_date_array("sensor.gazpar2haws_test", "gazpar2haws_test", "kWh", energy_array, 0)
+        await gazpar.publish_date_array("sensor.gazpar2haws_test", "gazpar2haws_test", "energy", "kWh", energy_array, 0)
 
         await self._haws.disconnect()
 
@@ -141,12 +141,13 @@ class TestGazpar:
             cost_array = None
 
         await gazpar.publish_date_array(
-            "sensor.gazpar2haws_energy_test", "gazpar2haws_energy_test", "kWh", energy_array, 0
+            "sensor.gazpar2haws_energy_test", "gazpar2haws_energy_test", "energy", "kWh", energy_array, 0
         )
 
         await gazpar.publish_date_array(
             "sensor.gazpar2haws_cost_test",
             "gazpar2haws_cost_test",
+            None,
             cost_array.value_unit,
             cost_array.value_array,
             0,

--- a/tests/test_haws.py
+++ b/tests/test_haws.py
@@ -98,7 +98,7 @@ class TestHomeAssistantWS:
             {"start": "2020-12-16T00:00:00+00:00", "state": 300.0, "sum": 300.0},
         ]
 
-        await self._haws.import_statistics("sensor.gazpar2haws_volume", "recorder", "test", "m³", statistics)
+        await self._haws.import_statistics("sensor.gazpar2haws_volume", "recorder", "test", "volume", "m³", statistics)
 
         await self._haws.disconnect()
 
@@ -130,6 +130,7 @@ class TestHomeAssistantWS:
             "sensor.gazpar2haws_nonexistent",
             "sensor.gazpar2haws_total_cost",
             "Gazpar2HAWS Total Cost",
+            None,
             "€",
             timezone="Europe/Paris",
             as_of_date=date.today(),
@@ -162,9 +163,9 @@ class TestHomeAssistantWS:
             {"start": "2024-12-16T00:00:00+00:00", "state": 300.0, "sum": 300.0},
         ]
 
-        await self._haws.import_statistics("sensor.gazpar2haws_cost", "recorder", "Old Cost", "€", old_statistics)
+        await self._haws.import_statistics("sensor.gazpar2haws_cost", "recorder", "Old Cost", None, "€", old_statistics)
         await self._haws.import_statistics(
-            "sensor.gazpar2haws_total_cost", "recorder", "New Total Cost", "€", new_statistics
+            "sensor.gazpar2haws_total_cost", "recorder", "New Total Cost", None, "€", new_statistics
         )
 
         # Wait a moment for Home Assistant to process the import
@@ -177,6 +178,7 @@ class TestHomeAssistantWS:
             "sensor.gazpar2haws_cost",
             "sensor.gazpar2haws_total_cost",
             "Gazpar2HAWS Total Cost",
+            None,
             "€",
             timezone="Europe/Paris",
             as_of_date=date(2024, 12, 31),
@@ -226,7 +228,7 @@ class TestHomeAssistantWS:
         ]
 
         await self._haws.import_statistics(
-            "sensor.gazpar2haws_cost_migrate_test", "recorder", "Old Cost", "€", old_statistics
+            "sensor.gazpar2haws_cost_migrate_test", "recorder", "Old Cost", None, "€", old_statistics
         )
 
         # Wait a moment for Home Assistant to process the import
@@ -239,6 +241,7 @@ class TestHomeAssistantWS:
             "sensor.gazpar2haws_cost_migrate_test",
             "sensor.gazpar2haws_total_cost_migrate_test",
             "Gazpar2HAWS Total Cost",
+            None,
             "€",
             timezone="Europe/Paris",
             as_of_date=date(2024, 12, 31),


### PR DESCRIPTION
Hello,

Based on the Home Assistant documentation, `unit_class` and `mean_type` become mandatory on statistics imports.

[Reference](https://github.com/home-assistant/core/blob/dev/homeassistant/components/recorder/websocket_api.py#L585).

Fix #95