### PR TITLE
[#103] Use ISO-4217 codes for currency sensors units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- [#103](https://github.com/ssenart/gazpar2haws/issues/103): Cost statistics now use ISO 4217 currency codes (EUR) instead of symbols (€) for Home Assistant integration. This improves standards compliance and ensures proper currency display across Home Assistant interfaces. The domain model continues to use currency symbols internally, maintaining clean separation between business logic and integration layers.
+
 ### Fixed
 
 - [#97](https://github.com/ssenart/gazpar2haws/issues/97): Specify `unit_class` and `mean_type` in statistics metadata to ensure proper sensor classification and display in Home Assistant.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -409,13 +409,15 @@ Always published:
 - `sensor.${name}_energy` (kWh)
 
 Published when pricing configuration is provided:
-- `sensor.${name}_consumption_cost` (€) - Variable cost from gas consumption
-- `sensor.${name}_subscription_cost` (€) - Fixed subscription fees
-- `sensor.${name}_transport_cost` (€) - Transport fees (fixed or variable)
-- `sensor.${name}_energy_taxes_cost` (€) - Energy taxes
-- `sensor.${name}_total_cost` (€) - Sum of all cost components
+- `sensor.${name}_consumption_cost` (EUR) - Variable cost from gas consumption
+- `sensor.${name}_subscription_cost` (EUR) - Fixed subscription fees
+- `sensor.${name}_transport_cost` (EUR) - Transport fees (fixed or variable)
+- `sensor.${name}_energy_taxes_cost` (EUR) - Energy taxes
+- `sensor.${name}_total_cost` (EUR) - Sum of all cost components
 
 Where `${name}` is the device name from configuration (default: `gazpar2haws`)
+
+**Note on Currency Units:** While the domain model and configuration use € symbols, statistics published to Home Assistant use ISO 4217 currency codes (EUR) for standards compliance. This conversion happens in the integration layer (gazpar.py) to maintain clean separation between business logic and external system requirements.
 
 **Note on Statistics vs Entities:** Gazpar2HAWS intentionally publishes cumulative statistics rather than regular state entities. This design choice is optimal for:
 - Historical energy/gas data tracking


### PR DESCRIPTION
Convert cost statistics from € symbols to EUR (ISO 4217) when publishing to Home Assistant. This maintains clean separation between the domain model (which uses €) and the integration layer.

Changes:
- Add _convert_euro_symbol_to_iso4217() method in gazpar.py
- Apply conversion to all 5 cost entities and migration code
- Update CLAUDE.md to reflect EUR units in published entities
- Add explanatory note about currency conversion
- Update CHANGELOG.md with ISO 4217 change